### PR TITLE
add a part in template contribute PR to ask for repro link

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,9 +20,9 @@ Place your template repository link here:
 - [ ] In the PR comment, if you can also add a link to the PR where you made your repo `azd` compatible this will allow us to provide feedback on your template and speed up the review process.
 
 # If you are submitting a resource to be added to the awesome-azd README:
-- [] Name of resource
-- [] Resource author - who created this resource? (so we can credit them!)
-- [] What section should this resource be included in? -Is the resource an article? A video? Something else?
+- [ ] Name of resource
+- [ ] Resource author - who created this resource? (so we can credit them!)
+- [ ] What section should this resource be included in? -Is the resource an article? A video? Something else?
 
 <!-- Once submitted, the issue will be reviewed - we plan to do reviews on a rolling basis at regular intervals. The process will include verifying all information required for the template gallery is provided and the template works (i.e., successfully deploys to Azure with `azd up`). 
  * If we have questions or enhancements, we will add comments in issue thread (**issue stays open**)


### PR DESCRIPTION
Add a request to ask users to put their repro link when opening a PR.
Make team easier review template contribute PRs.
Add `[ ]` in [PULL_REQUEST_TEMPLATE.md](https://github.com/Azure/awesome-azd/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1#L19-L22)


It shows like this without space:
- [] Name of resource
- [] Resource author - who created this resource? (so we can credit them!)
- [] What section should this resource be included in? -Is the resource an article? A video? Something else?
