### PR TITLE
Move Django to frameworks

### DIFF
--- a/website/src/data/tags.tsx
+++ b/website/src/data/tags.tsx
@@ -183,11 +183,6 @@ export const Tags: { [type in TagType]: Tag } = {
     description: "Template contains Python app code",
     type: "Language",
   },
-  django: {
-    label: "Django",
-    description: "Template contains Django web app code",
-    type: "Language",
-  },
   reactjs: {
     label: "React.js",
     description: "Template architecture uses React.js",
@@ -236,6 +231,11 @@ export const Tags: { [type in TagType]: Tag } = {
   flask: {
     label: "Flask",
     description: "Template architecture uses Flask web framework",
+    type: "Framework",
+  },
+  django: {
+    label: "Django",
+    description: "Template architecture uses Django web framework",
     type: "Framework",
   },
   nestjs: {


### PR DESCRIPTION
I was surprised to see Django listed as a language, since I consider it a Framework. This moves it and changes its category.

I similarly think of React.JS as being a framework, but I guess there's a way in which it's a language. 