### PR TITLE
add font fallback for azd init command in card footer

### DIFF
--- a/website/src/components/gallery/ShowcaseCard/index.tsx
+++ b/website/src/components/gallery/ShowcaseCard/index.tsx
@@ -285,11 +285,6 @@ const useStyles = makeStyles({
     color: "#424242",
     fontWeight: "600",
   },
-  cardFooterAzdCommand: {
-    fontSize: "11px",
-    fontFamily: '"Consolas-Regular", Helvetica',
-    color: "#606060",
-  },
 });
 
 function ShowcaseCard({ user }: { user: User }) {
@@ -526,7 +521,7 @@ function ShowcaseCard({ user }: { user: User }) {
             flex: "1",
             border: "1px solid #d1d1d1",
             fontSize: "11px",
-            fontFamily: "Consolas",
+            fontFamily: "Consolas, Courier New, Courier, monospace",
             WebkitTextFillColor: "#717171",
           }}
         />

--- a/website/src/data/tags.tsx
+++ b/website/src/data/tags.tsx
@@ -191,7 +191,7 @@ export const Tags: { [type in TagType]: Tag } = {
   reactjs: {
     label: "React.js",
     description: "Template architecture uses React.js",
-    type: "Language",
+    type: "Tools",
   },
   nodejs: {
     label: "Node.js",


### PR DESCRIPTION
Azd init command is using Consolas. Added fallback font family Courier New, Courier, monospace in case Consolas is not rendered. 