### PR TITLE
Update video on about page

### DIFF
--- a/website/src/pages/about/index.js
+++ b/website/src/pages/about/index.js
@@ -13,7 +13,7 @@ function HomepageHeader() {
     <header className={clsx('hero hero--primary', styles.heroBanner)}>
       <div className="container">
         <h1 className="hero__title">{siteConfig.title}</h1>
-        <iframe width="773" height="435" src="https://www.youtube.com/embed/VTk-FhJyo7s" title="Introducing the Azure Developer CLI (azd) | Azure Friday" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen>
+        <iframe width="773" height="435" src="https://www.youtube.com/embed/9z3PiHSCcYs?si=F1yKpoiOQnzb4o-K" title="Azure Developer CLI: GitHub to cloud in minutes - Universe 2022" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen>
         </iframe>
 
         <p className="hero__subtitle">{siteConfig.tagline}</p>


### PR DESCRIPTION
video on the about page currently is from over a year ago. We replaced that video in our docs and should do that here as well