### PR TITLE
remove duplicate copy button 

### DIFF
--- a/website/src/components/gallery/ShowcaseCard/index.tsx
+++ b/website/src/components/gallery/ShowcaseCard/index.tsx
@@ -266,7 +266,6 @@ function ShowcaseCard({ user }: { user: User }):JSX.Element {
               }}
             >
               <img src={useBaseUrl("/img/Copy.svg")} height={20} alt="Copy" />
-              <img src={useBaseUrl("/img/Copy.svg")} height={20} alt="Copy" />
             </Button>
           </PopoverTrigger>
 

--- a/website/src/pages/about/index.js
+++ b/website/src/pages/about/index.js
@@ -65,8 +65,15 @@ function HomepageHeader({ colorMode }) {
 
 const HomeApp = () => {
   const { colorMode } = useColorMode();
+  const [loading, setLoading] = useState(true);
 
-  return (
+  useEffect(() => {
+    setTimeout(() => {
+      setLoading(false);
+    }, 100);
+  }, []);
+
+  return !loading ? (
     <FluentProvider
       theme={colorMode == "dark" ? teamsDarkTheme : teamsLightTheme}
       className={styles.backgroundColor}
@@ -76,7 +83,7 @@ const HomeApp = () => {
         <HomepageFeatures />
       </div>
     </FluentProvider>
-  );
+  ) : null;
 };
 
 export default function Home() {


### PR DESCRIPTION
remove duplicate copy button caused by auto-merge
add loading in about page to prevent page break error when directly refreshing about page