### PR TITLE
Update title and description of Next.js on Container Apps template

### DIFF
--- a/website/static/templates.json
+++ b/website/static/templates.json
@@ -1111,8 +1111,8 @@
     ]
   },
   {
-    "title": "Next.js 13 on Container Apps",
-    "description": "A blueprint for getting a Next.js 13 app running on Azure Container Apps with CDN and Application Insights.",
+    "title": "Next.js on Container Apps",
+    "description": "A blueprint for getting a Next.js app running on Azure Container Apps with CDN and Application Insights.",
     "preview": "./templates/images/nextjs-aca.png",
     "website": "https://github.com/CMeeg",
     "author": "Chris Meagher",


### PR DESCRIPTION
I'd like to update the title and description of the template I submitted to the gallery, please.

Next.js 14 has recently been released and I will soon update the Next.js app in my azd template repo to the latest version, but because I put "Next.js 13" in the template title and description that might be confusing for people wanting to use the template!