### PR TITLE
remove .npmrc as we are not using private npm package

### DIFF
--- a/website/.npmrc
+++ b/website/.npmrc
@@ -1,2 +1,0 @@
-registry=https://msasg.pkgs.visualstudio.com/_packaging/1DS-SDK/npm/registry/ 
-always-auth=true


### PR DESCRIPTION
fix error of npm `Unable to authenticate, your authentication token seems to be invalid`