### PR TITLE
Add dbroeglin/azure-rails-starter to the gallery

### DIFF
--- a/website/static/templates.json
+++ b/website/static/templates.json
@@ -1559,5 +1559,23 @@
       "community",
       "new"
     ]
+  },
+  {
+    "title": "Sample Ruby on Rails app deployed (Bicep) on Azure Container App with PostgreSQL",
+    "description": "A sample Ruby on Rails Web App, made for demonstration purposes only, and deployed to Azure Container App and PostgreSQL.",
+    "preview": "./templates/images/azure-rails-starter.png",
+    "website": "https://github.com/dbroeglin",
+    "author": "Dominique Broeglin",
+    "source": "https://github.com/dbroeglin/azure-rails-starter",
+    "tags": [
+      "ruby",
+      "ruyonrails",
+      "bicep",
+      "aca",
+      "azuredb-postgreSQL",
+      "monitor",
+      "community",
+      "new"
+    ]
   }
 ]


### PR DESCRIPTION
# If you are submitting a new `azd` template to the gallery
Fill this out if you want your template to be added to the awesome-azd gallery!

### Your template repository
Place your template repository link here: https://github.com/dbroeglin/azure-rails-starter

- [x] Added an entry to https://github.com/Azure/awesome-azd/blob/main/website/src/data/users.tsx that includes:
    - [x] **Template title** - A short title that reflects the local application stack that someone could use to get their application on Azure (e.g. "Containerized React Web App with Java API and MongoDB")
    - [x] **Description** - 1-2 sentence description of the architecture (e.g. Azure services) or solution that is defined by the template.
    - [x] **Architecture Diagram or Application Screenshot** - The image should include all services and their connections ([example](https://github.com/Azure-Samples/todo-csharp-sql/blob/main/assets/resources.png)). You should add the image to the `website/src/data/images/`.
    - [x] **Link to Author's GitHub or other relevant website** - Used for attribution
    - [x] **Author's Name** -  Name to credit on the gallery card
    - [x] **Link to template source** - Link to the template GitHub repo 
    - [x] **Tags** - Specify [tags](https://github.com/Azure/awesome-azd/blob/main/website/src/data/tags.tsx) to represent the template. If you don't see a relevant tag for your template? Feel free to add one!
        
        **Required tags**:
      - [x] Tag your template as Micrsoft-authored (`"msft"`) or Community-authored (`"community"`)
      - [x] Tag the IaC provider (`"bicep"` or `"terraform"`)
      - [x] At least 1 tag for programming language used
      - [x] At least 1 tag for Azure services integrated
      - [x] Add the `"new"` tag for any newly authored templates

- [x] In the PR comment, if you can also add a link to the PR where you made your repo `azd` compatible this will allow us to provide feedback on your template and speed up the review process. **The whole repository has been created as an `azd` template**




