### PR TITLE
Add a line on contribute doc to ask author publishing Microsoft authorized template to azure samples browser

### DIFF
--- a/website/docs/contribute.md
+++ b/website/docs/contribute.md
@@ -22,7 +22,7 @@ To submit a template:
     - **Author's Name** - Name to credit on the gallery card
     - **Link to template source** - Link to the template GitHub repo
     - **Tags** - One or more [tags](https://github.com/Azure/awesome-azd/blob/main/website/src/data/tags.tsx) representing the template. Provide at least 1 tag for programming language used and at least 1 tag for Azure services integrated. Also tag the IaC provider (Bicep or Terraform). If you don't see a relevant tag for your template? Feel free to add one!
-2. If the template is microsoft authorized, we encourage to [publish the template to azure samples browsers](https://review.learn.microsoft.com/en-us/help/contribute/samples/process/onboarding?branch=main). 
+2. If the template is Microsoft-authored, we encourage you to also [publish it to learn.microsoft.com/samples](https://review.learn.microsoft.com/en-us/help/contribute/samples/process/onboarding?branch=main). 
 3. Open a PR!
 4. If possible, add a link to the PR in your repo where you made your app `azd` compatible to the PR description. This will help us provide feedback on your template and speed up the review process. 
 


### PR DESCRIPTION
The manual test team are constantly tracking and creating PRs to publish msft authorized templates to azure samples browser. We should consider letting the author decides if they want to add their templates on azure samples browser.