### PR TITLE
Add a line on PR description to ask author publishing Microsoft authorized template to azure samples browser

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,6 +25,7 @@ Place your template repository link here:
       - [ ] Add the `"new"` tag for any newly authored templates
 
 - [ ] In the PR comment, if you can also add a link to the PR where you made your repo `azd` compatible this will allow us to provide feedback on your template and speed up the review process.
+- [ ] If the template is Microsoft-authored, we encourage you to also [publish it to learn.microsoft.com/samples](https://review.learn.microsoft.com/en-us/help/contribute/samples/process/onboarding?branch=main).
 
 # If you are submitting a resource to be added to the awesome-azd README:
 - [ ] Name of resource


### PR DESCRIPTION
As a follow up PR in https://github.com/Azure/awesome-azd/pull/404. Adding this line into PR description to make sure people are aware of it when they contribute a template. 