### PR TITLE
fix: include author tags for recently added templates

### DIFF
--- a/website/static/templates.json
+++ b/website/static/templates.json
@@ -2096,7 +2096,8 @@
       "aicollection",
       "openai",
       "blobstorage",
-      "aisearch"
+      "aisearch",
+      "msft"
     ]
   },
   {
@@ -2114,7 +2115,8 @@
       "openai",
       "managedidentity",
       "openai",
-      "aicollection"
+      "aicollection",
+      "msft"
     ]
   },
   {
@@ -2129,7 +2131,8 @@
       "managedidentity",
       "aca",
       "azureai",
-      "aicollection"
+      "aicollection",
+      "msft"
     ]
   },
   {
@@ -2143,7 +2146,8 @@
       "python",
       "pinecone",
       "aca",
-      "aicollection"
+      "aicollection",
+      "community"
     ]
   }
 ]

--- a/website/static/templates.json
+++ b/website/static/templates.json
@@ -2116,7 +2116,8 @@
       "managedidentity",
       "openai",
       "aicollection",
-      "msft"
+      "msft",
+      "new"
     ]
   },
   {
@@ -2132,7 +2133,8 @@
       "aca",
       "azureai",
       "aicollection",
-      "msft"
+      "msft",
+      "new"
     ]
   },
   {
@@ -2147,7 +2149,8 @@
       "pinecone",
       "aca",
       "aicollection",
-      "community"
+      "community",
+      "new"
     ]
   }
 ]


### PR DESCRIPTION
In #432 I forgot to include author tags (msft / community) for the templates I added