### PR TITLE
remove agent-openai-python-prompty-langchain-pinecone & agent-python-openai-prompty-langchain

### DIFF
--- a/website/static/templates.json
+++ b/website/static/templates.json
@@ -1975,23 +1975,6 @@
     ]
   },
   {
-    "title": "Function Calling with Prompty, LangChain and Elastic Search",
-    "description": "Function calling for vector database lookup based on user question.",
-    "preview": "./templates/images/agent-python-openai-prompty-langchain-architecture-diagram.png",
-    "website": "https://github.com/Azure-Samples",
-    "author": "Azure Content Team",
-    "source": "https://github.com/Azure-Samples/agent-python-openai-prompty-langchain",
-    "tags": [
-      "msft",
-      "aicollection",
-      "python",
-      "openai",
-      "aistudio",
-      "bicep",
-      "ai"
-    ]
-  },
-  {
     "title": "Contoso Chat Retail with Azure AI Studio and Promptflow",
     "description": "This sample has the full End2End process of creating RAG application with Prompt Flow and AI Studio. It includes GPT 3.5 Turbo LLM application code, evaluations, deployment automation with AZD CLI, GitHub actions for evaluation and deployment and intent mapping for multiple LLM task mapping.",
     "preview": "./templates/images/contoso-chat-architecture-diagram.png",


### PR DESCRIPTION
these templates are being deprecated and the repos were made private 
https://github.com/Azure-Samples/agent-openai-python-prompty-langchain-pinecone 
https://github.com/Azure-Samples/agent-python-openai-prompty-langchain