### PR TITLE
Fix video url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ New to `azd`? Check out the `azd` videos in the Open at Microsoft series:
 
 [![Image of Intro to Azure Developer CLI (azd)](https://img.youtube.com/vi/KDgR-TXtOgM/0.jpg)](https://www.youtube.com/embed/KDgR-TXtOgM)
 
-[![Image of How to deploy to Azure with the Azure Developer CLI](https://img.youtube.com/vi/f_HpDpEmWZ4/0.jpg)](https://www.youtube.com/embed/KDgR-TXtOgM)
+[![Image of How to deploy to Azure with the Azure Developer CLI](https://img.youtube.com/vi/f_HpDpEmWZ4/0.jpg)](https://www.youtube.com/embed/f_HpDpEmWZ4)
 
 The Azure Developer CLI (`azd`) is an open-source tool that accelerates the time it takes for developers to get started on Azure by using developer-friendly commands that map to key stages in your workflow (code, build, deploy, monitor). The Azure Developer CLI uses application templates that include everything you need to get up and running on Azure, then allows you to customize them. The templates include application code and reusable infrastructure as code assets written in Bicep or Terraform and are infused with cloud best practices.  More than that, they cover end-to-end scenarios that go far beyond "Hello World!".
 


### PR DESCRIPTION
Currently both videos are pointing to the same Youtube url. Fixed this with this PR.