### PR TITLE
Fix link to GitHub author for the SharePoint Online webhooks template 

### DIFF
--- a/website/static/templates.json
+++ b/website/static/templates.json
@@ -2991,7 +2991,7 @@
     "title": "Create SharePoint Online webhooks with an Azure function app (Node.js)",
     "description": "A secured Azure function app that connects to your SharePoint Online tenant, to register and manage webhooks, and process the notifications from SharePoint.",
     "preview": "./templates/images/azd-functions-sharepoint-webhooks.png",
-    "website": "https://github.com/Azure-Samples",
+    "website": "https://github.com/Yvand",
     "author": "Yvan Duhamel",
     "source": "https://github.com/Azure-Samples/azd-functions-sharepoint-webhooks",
     "tags": [


### PR DESCRIPTION
This PR is a follow up of https://github.com/Azure/awesome-azd/pull/495 to fix the link to the GitHub account as shown below, on template `azd-functions-sharepoint-webhooks`:

![image](https://github.com/user-attachments/assets/62de0e70-8fd9-4351-8533-fa4e3ec2663c)

