### PR TITLE
Add main and search accessibility landmarks to Home and Getting Started pages

### DIFF
--- a/website/src/components/gallery/ShowcaseTemplateSearch/index.tsx
+++ b/website/src/components/gallery/ShowcaseTemplateSearch/index.tsx
@@ -70,6 +70,7 @@ function FilterBar(): React.JSX.Element {
         id="filterBar"
         value={readSearchName(location.search) != null ? value : ""}
         placeholder="Search for an azd template..."
+        role="search"
         onClear={(e) => {
           setValue(null);
           const newSearch = new URLSearchParams(location.search);

--- a/website/src/pages/getting-started/index.js
+++ b/website/src/pages/getting-started/index.js
@@ -85,10 +85,10 @@ const HomeApp = () => {
       theme={colorMode == "dark" ? teamsDarkTheme : teamsLightTheme}
       className={styles.backgroundColor}
     >
-      <div className={styles.container}>
+      <main className={styles.container}>
         <HomepageHeader colorMode={colorMode} />
         <HomepageFeatures />
-      </div>
+      </main>
     </FluentProvider>
   ) : null;
 };

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -67,32 +67,34 @@ const App = () => {
     <FluentProvider
       theme={colorMode == "dark" ? teamsDarkTheme : teamsLightTheme}
     >
-      <ShowcaseTemplateSearch />
-      <div className={styles.filterAndCard}>
-        <div className={styles.filter}>
-          <ShowcaseLeftFilters
-            activeTags={activeTags}
-            selectedCheckbox={selectedCheckbox}
-            setSelectedCheckbox={setSelectedCheckbox}
-            location={location}
-            setSelectedTags={setSelectedTags}
-            selectedTags={selectedTags}
-            readSearchTags={readSearchTags}
-            replaceSearchTags={replaceSearchTags}
-          />
+      <main>
+        <ShowcaseTemplateSearch />
+        <div className={styles.filterAndCard}>
+          <div className={styles.filter}>
+            <ShowcaseLeftFilters
+              activeTags={activeTags}
+              selectedCheckbox={selectedCheckbox}
+              setSelectedCheckbox={setSelectedCheckbox}
+              location={location}
+              setSelectedTags={setSelectedTags}
+              selectedTags={selectedTags}
+              readSearchTags={readSearchTags}
+              replaceSearchTags={replaceSearchTags}
+            />
+          </div>
+          <div className={styles.card}>
+            <ShowcaseCardPage
+              setActiveTags={setActiveTags}
+              selectedTags={selectedTags}
+              setSelectedCheckbox={setSelectedCheckbox}
+              location={location}
+              setSelectedTags={setSelectedTags}
+              readSearchTags={readSearchTags}
+              replaceSearchTags={replaceSearchTags}
+            />
+          </div>
         </div>
-        <div className={styles.card}>
-          <ShowcaseCardPage
-            setActiveTags={setActiveTags}
-            selectedTags={selectedTags}
-            setSelectedCheckbox={setSelectedCheckbox}
-            location={location}
-            setSelectedTags={setSelectedTags}
-            readSearchTags={readSearchTags}
-            replaceSearchTags={replaceSearchTags}
-          />
-        </div>
-      </div>
+      </main>
     </FluentProvider>
   ) : null;
 };


### PR DESCRIPTION
This PR adds accessibility landmarks to mark the main and search sections of the **Home** and **Getting Started** pages. These landmarks help guide users who rely on screen readers to navigate the page in landmark mode. The navigation and contentinfo landmarks already existed prior to these changes.

### Home

![image](https://github.com/user-attachments/assets/855bc360-d8e5-4e05-be47-afde7c493cc9)

### Getting Started

![image](https://github.com/user-attachments/assets/dba140be-1484-415a-909c-7198783cf65e)
