### PR TITLE
contoso-creative-writer: Update metadata to Bicep from Terraform

### DIFF
--- a/website/static/templates.json
+++ b/website/static/templates.json
@@ -2436,7 +2436,7 @@
     "tags": [
       "msft",
       "aicollection",
-      "terraform",
+      "bicep",
       "ai"
     ],
     "azure_service": [


### PR DESCRIPTION
Fixing the metadata tags for Terraform to Bicep.

I noticed while looking up samples, that since https://github.com/Azure-Samples/contoso-creative-writer/pull/91/files, contoso-creative-writer has been using Bicep and not Terraform.

@marlenezw for awareness