### PR TITLE
Remove langfuse-on-azure from template gallery

### DIFF
--- a/website/static/templates.json
+++ b/website/static/templates.json
@@ -2043,25 +2043,6 @@
     "id": "087c35ef-edc0-4794-8bf5-51bc265269b0"
   },
   {
-    "title": "Langfuse on Azure",
-    "description": "Deploy Langfuse (open-source LLM observability platform) to Azure Container Apps with PostgreSQL Flexible Server.",
-    "preview": "./templates/images/aca_postgres_keyvault.png",
-    "authorUrl": "https://github.com/pamelafox",
-    "author": "Pamela Fox",
-    "source": "https://github.com/Azure-Samples/langfuse-on-azure",
-    "tags": [
-      "ai",
-      "msft",
-      "bicep"
-    ],
-    "azureServices": [
-      "aca",
-      "azuredb-postgreSQL",
-      "keyvault"
-    ],
-    "id": "d76ccdef-e735-4891-af13-b54e14f1a3fb"
-  },
-  {
     "title": "PostgreSQL + Pgvector",
     "description": "Deploy a PostgreSQL Flexible Server with Pgvector extension and keyless auth, then access it from Python scripts.",
     "preview": "./templates/images/postgres_entra.png",


### PR DESCRIPTION
I have removed the langfuse template from the gallery, as it is using an old version of langfuse, and the langfuse team itself has made a more modern version here:
https://github.com/langfuse/langfuse-terraform-azure
They may be able to add azd to that repository, but for now, I want to remove links to the old version.