### PR TITLE
Fix link for samples onboarding in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,7 +26,7 @@ Place your template repository link here:
       - [ ] Add the `"new"` tag for any newly authored templates
 
 - [ ] In the PR comment, if you can also add a link to the PR where you made your repo `azd` compatible this will allow us to provide feedback on your template and speed up the review process.
-- [ ] If the template is Microsoft-authored, we encourage you to also [publish it to learn.microsoft.com/samples](https://review.learn.microsoft.com/en-us/help/contribute/samples/process/onboarding?branch=main).
+- [ ] If the template is Microsoft-authored, we encourage you to also [publish it to learn.microsoft.com/samples](https://learn.microsoft.com/en-us/help/contribute/samples/process/onboarding?branch=main).
 
 # If you are submitting a resource to be added to the awesome-azd README:
 - [ ] Name of resource


### PR DESCRIPTION
The link changed, now you need to go to the main learn, but be signed in.