### PR TITLE
fix: replace invalid on:[] with workflow_dispatch to stop phantom CI failures

### DIFF
--- a/.github/workflows/extension-submission.yml
+++ b/.github/workflows/extension-submission.yml
@@ -28,7 +28,8 @@ name: Extension Submission
 #       website:
 #         description: "Extension documentation website URL (optional)"
 #         required: false
-on: []
+on:
+  workflow_dispatch: {}
 
 permissions:
   contents: write

--- a/.github/workflows/sync-extension-versions.yml
+++ b/.github/workflows/sync-extension-versions.yml
@@ -4,7 +4,8 @@ name: Sync Extension Versions
 #   schedule:
 #     - cron: "0 6 * * *" # Daily at 6 AM UTC
 #   workflow_dispatch: # Allow manual trigger
-on: []
+on:
+  workflow_dispatch: {}
 
 permissions:
   contents: write


### PR DESCRIPTION
## Problem

The `extension-submission.yml` and `sync-extension-versions.yml` workflows were disabled during PR #802 by commenting out their triggers and replacing them with `on: []`.

However, `on: []` is invalid YAML for GitHub Actions triggers — it causes every push to fire the workflow, which then immediately fails with 0 jobs. This pollutes the Actions tab with persistent red failures.

## Fix

Replace `on: []` with:

```yaml
on:
  workflow_dispatch: {}
```

This makes the workflows manually-dispatchable only, matching the original disabled-but-available intent without generating phantom failures.

## Changes

- `.github/workflows/extension-submission.yml`: `on: []` → `on: workflow_dispatch: {}`
- `.github/workflows/sync-extension-versions.yml`: `on: []` → `on: workflow_dispatch: {}`

Original commented-out triggers are preserved as documentation.