### PR TITLE
Add template: functions-quickstart-java-azd-service-bus (Issue #827)

### DIFF
--- a/validation_result.json
+++ b/validation_result.json
@@ -1,0 +1,1 @@
+{"valid":true}

--- a/validation_result.json
+++ b/validation_result.json
@@ -1,1 +1,0 @@
-{"valid":true}

--- a/website/static/templates.json
+++ b/website/static/templates.json
@@ -7222,5 +7222,30 @@
       "bicep"
     ],
     "id": "ad77e6e6-af2c-4390-bb8c-8ca64cf540ce"
+  },
+  {
+    "title": "functions-e2e-sb-vnet",
+    "description": "",
+    "preview": "https://raw.githubusercontent.com/Azure-Samples/functions-quickstart-java-azd-service-bus/main/img/SB-VNET.png",
+    "authorUrl": "https://github.com/Azure-Samples",
+    "author": "Azure-Samples",
+    "source": "https://github.com/azure-samples/functions-quickstart-java-azd-service-bus",
+    "tags": [
+      "msft",
+      "new"
+    ],
+    "IaC": [
+      "bicep"
+    ],
+    "id": "6b365ccc-04da-4a56-8a5f-51731f126712",
+    "languages": [
+      "java"
+    ],
+    "frameworks": [
+      "rag"
+    ],
+    "azureServices": [
+      "functions"
+    ]
   }
 ]

--- a/website/static/templates.json
+++ b/website/static/templates.json
@@ -7224,9 +7224,9 @@
     "id": "ad77e6e6-af2c-4390-bb8c-8ca64cf540ce"
   },
   {
-    "title": "functions-e2e-sb-vnet",
+    "title": "Azure Functions with Service Bus and VNet (Java)",
     "description": "End-to-end Java sample demonstrating secure triggering of a Flex Consumption function app from a Service Bus instance secured in a virtual network, using managed identity and VNet integration.",
-    "preview": "https://raw.githubusercontent.com/Azure-Samples/functions-quickstart-java-azd-service-bus/main/img/SB-VNET.png",
+    "preview": "./templates/images/functions-e2e-sb-vnet.png",
     "authorUrl": "https://github.com/Azure-Samples",
     "author": "Anthony Chu",
     "source": "https://github.com/azure-samples/functions-quickstart-java-azd-service-bus",

--- a/website/static/templates.json
+++ b/website/static/templates.json
@@ -7229,7 +7229,7 @@
     "preview": "./templates/images/functions-e2e-sb-vnet.png",
     "authorUrl": "https://github.com/Azure-Samples",
     "author": "Anthony Chu",
-    "source": "https://github.com/azure-samples/functions-quickstart-java-azd-service-bus",
+    "source": "https://github.com/Azure-Samples/functions-quickstart-java-azd-service-bus",
     "tags": [
       "msft",
       "new"

--- a/website/static/templates.json
+++ b/website/static/templates.json
@@ -7225,10 +7225,10 @@
   },
   {
     "title": "functions-e2e-sb-vnet",
-    "description": "",
+    "description": "End-to-end Java sample demonstrating secure triggering of a Flex Consumption function app from a Service Bus instance secured in a virtual network, using managed identity and VNet integration.",
     "preview": "https://raw.githubusercontent.com/Azure-Samples/functions-quickstart-java-azd-service-bus/main/img/SB-VNET.png",
     "authorUrl": "https://github.com/Azure-Samples",
-    "author": "Azure-Samples",
+    "author": "Anthony Chu",
     "source": "https://github.com/azure-samples/functions-quickstart-java-azd-service-bus",
     "tags": [
       "msft",
@@ -7241,11 +7241,11 @@
     "languages": [
       "java"
     ],
-    "frameworks": [
-      "rag"
-    ],
     "azureServices": [
-      "functions"
+      "functions",
+      "servicebus",
+      "vnets",
+      "managedidentity"
     ]
   }
 ]


### PR DESCRIPTION
Closes #827

# If you are submitting a new `azd` template to the gallery

### Your template repository
https://github.com/Azure-Samples/functions-quickstart-java-azd-service-bus

- [x] Added an entry to https://github.com/Azure/awesome-azd/blob/main/website/static/templates.json that includes:
    - [x] **Template title** - `functions-e2e-sb-vnet`
    - [x] **Description** - End-to-end Java sample demonstrating secure triggering of a Flex Consumption function app from a Service Bus instance secured in a virtual network, using managed identity and VNet integration.
    - [x] **Architecture Diagram or Application Screenshot** - https://raw.githubusercontent.com/Azure-Samples/functions-quickstart-java-azd-service-bus/main/img/SB-VNET.png
    - [x] **Link to Author's GitHub or other relevant website** - https://github.com/Azure-Samples
    - [x] **Author's Name** - Anthony Chu
    - [x] **Link to template source** - https://github.com/azure-samples/functions-quickstart-java-azd-service-bus
    - [x] **Tags** - `msft`, `new`
    - [x] **Languages Tags** - `java`
    - [x] **Azure Services Tags** - `functions`, `servicebus`, `vnets`, `managedidentity`
    - [x] **ID** - `6b365ccc-04da-4a56-8a5f-51731f126712`

    **Required tags**:
    - [x] Tag your template as Microsoft-authored (`msft`)
    - [x] Tag the IaC provider (`bicep`)
    - [x] Add the `new` tag for any newly authored templates

- [ ] In the PR comment, if you can also add a link to the PR where you made your repo `azd` compatible this will allow us to provide feedback on your template and speed up the review process.
- [ ] If the template is Microsoft-authored, we encourage you to also [publish it to learn.microsoft.com/samples](https://learn.microsoft.com/en-us/help/contribute/samples/process/onboarding?branch=main).

Deployment Proof:
<img width="1419" height="784" alt="image" src="https://github.com/user-attachments/assets/3ffb67f6-aef6-4980-b84e-9334688405b4" />
<img width="556" height="599" alt="image" src="https://github.com/user-attachments/assets/eb486823-293f-4b94-ae66-fd9ca73d6181" />

---
*This PR was created manually after the automated workflow failed to create it due to insufficient permissions. Template submission from issue #827.*