### PR TITLE
Add template: functions-quickstart-powershell-azd-service-bus (Issue #828)

### DIFF
--- a/validation_result.json
+++ b/validation_result.json
@@ -1,0 +1,1 @@
+{"valid":true}

--- a/validation_result.json
+++ b/validation_result.json
@@ -1,1 +1,0 @@
-{"valid":true}

--- a/website/static/templates.json
+++ b/website/static/templates.json
@@ -7225,24 +7225,25 @@
   },
   {
     "title": "functions-e2e-sb-vnet-powershell",
-    "description": "",
+    "description": "End-to-end PowerShell sample demonstrating secure triggering of a Flex Consumption function app from a Service Bus instance secured in a virtual network, using managed identity and VNet integration.",
     "preview": "https://raw.githubusercontent.com/Azure-Samples/functions-quickstart-powershell-azd-service-bus/main/img/SB-VNET.png",
     "authorUrl": "https://github.com/Azure-Samples",
-    "author": "Azure-Samples",
+    "author": "Anthony Chu",
     "source": "https://github.com/azure-samples/functions-quickstart-powershell-azd-service-bus",
     "tags": [
       "msft",
-      "new"
+      "new",
+      "powershell"
     ],
     "IaC": [
       "bicep"
     ],
     "id": "51f10949-c699-4a42-88ab-84e48b7c7a6e",
-    "frameworks": [
-      "rag"
-    ],
     "azureServices": [
-      "functions"
+      "functions",
+      "servicebus",
+      "vnets",
+      "managedidentity"
     ]
   }
 ]

--- a/website/static/templates.json
+++ b/website/static/templates.json
@@ -7222,5 +7222,27 @@
       "bicep"
     ],
     "id": "ad77e6e6-af2c-4390-bb8c-8ca64cf540ce"
+  },
+  {
+    "title": "functions-e2e-sb-vnet-powershell",
+    "description": "",
+    "preview": "https://raw.githubusercontent.com/Azure-Samples/functions-quickstart-powershell-azd-service-bus/main/img/SB-VNET.png",
+    "authorUrl": "https://github.com/Azure-Samples",
+    "author": "Azure-Samples",
+    "source": "https://github.com/azure-samples/functions-quickstart-powershell-azd-service-bus",
+    "tags": [
+      "msft",
+      "new"
+    ],
+    "IaC": [
+      "bicep"
+    ],
+    "id": "51f10949-c699-4a42-88ab-84e48b7c7a6e",
+    "frameworks": [
+      "rag"
+    ],
+    "azureServices": [
+      "functions"
+    ]
   }
 ]

--- a/website/static/templates.json
+++ b/website/static/templates.json
@@ -7224,9 +7224,9 @@
     "id": "ad77e6e6-af2c-4390-bb8c-8ca64cf540ce"
   },
   {
-    "title": "functions-e2e-sb-vnet-powershell",
+    "title": "Azure Functions with Service Bus and VNet (PowerShell)",
     "description": "End-to-end PowerShell sample demonstrating secure triggering of a Flex Consumption function app from a Service Bus instance secured in a virtual network, using managed identity and VNet integration.",
-    "preview": "https://raw.githubusercontent.com/Azure-Samples/functions-quickstart-powershell-azd-service-bus/main/img/SB-VNET.png",
+    "preview": "./templates/images/functions-e2e-sb-vnet.png",
     "authorUrl": "https://github.com/Azure-Samples",
     "author": "Anthony Chu",
     "source": "https://github.com/azure-samples/functions-quickstart-powershell-azd-service-bus",

--- a/website/static/templates.json
+++ b/website/static/templates.json
@@ -7229,7 +7229,7 @@
     "preview": "./templates/images/functions-e2e-sb-vnet.png",
     "authorUrl": "https://github.com/Azure-Samples",
     "author": "Anthony Chu",
-    "source": "https://github.com/azure-samples/functions-quickstart-powershell-azd-service-bus",
+    "source": "https://github.com/Azure-Samples/functions-quickstart-powershell-azd-service-bus",
     "tags": [
       "msft",
       "new",


### PR DESCRIPTION
Closes #828

# If you are submitting a new `azd` template to the gallery

### Your template repository
https://github.com/Azure-Samples/functions-quickstart-powershell-azd-service-bus

- [x] Added an entry to https://github.com/Azure/awesome-azd/blob/main/website/static/templates.json that includes:
    - [x] **Template title** - `functions-e2e-sb-vnet-powershell`
    - [x] **Description** - End-to-end PowerShell sample demonstrating secure triggering of a Flex Consumption function app from a Service Bus instance secured in a virtual network, using managed identity and VNet integration.
    - [x] **Architecture Diagram or Application Screenshot** - https://raw.githubusercontent.com/Azure-Samples/functions-quickstart-powershell-azd-service-bus/main/img/SB-VNET.png
    - [x] **Link to Author's GitHub or other relevant website** - https://github.com/Azure-Samples
    - [x] **Author's Name** - Anthony Chu
    - [x] **Link to template source** - https://github.com/azure-samples/functions-quickstart-powershell-azd-service-bus
    - [x] **Tags** - `msft`, `new`, `powershell`
    - [x] **Azure Services Tags** - `functions`, `servicebus`, `vnets`, `managedidentity`
    - [x] **ID** - `51f10949-c699-4a42-88ab-84e48b7c7a6e`

    **Required tags**:
    - [x] Tag your template as Microsoft-authored (`msft`)
    - [x] Tag the IaC provider (`bicep`)
    - [x] Add the `new` tag for any newly authored templates

    **Note on languages**: PowerShell is defined as `type: "Tools"` in tags.tsx, not `type: "Language"`, so it is placed in `tags` rather than `languages`.

- [ ] In the PR comment, if you can also add a link to the PR where you made your repo `azd` compatible this will allow us to provide feedback on your template and speed up the review process.
- [ ] If the template is Microsoft-authored, we encourage you to also [publish it to learn.microsoft.com/samples](https://learn.microsoft.com/en-us/help/contribute/samples/process/onboarding?branch=main).

Proof of Successful Deployment:
<img width="1136" height="794" alt="image" src="https://github.com/user-attachments/assets/d8e441b7-274f-4647-b92c-b53a2f42999b" />

Additional Validations
1. Function Up and Running
2. Function Triggered: 
<img width="568" height="570" alt="image" src="https://github.com/user-attachments/assets/36650653-5c72-4685-8247-9ebfb5f68119" />


---
*This PR was created manually after the automated workflow failed to create it due to insufficient permissions. Template submission from issue #828.*