### PR TITLE
Update source link for Hello World agent and remove Foundry Agent

### DIFF
--- a/website/static/agent-templates.json
+++ b/website/static/agent-templates.json
@@ -4,16 +4,8 @@
     "description": "Minimal Hello World agent using the Responses protocol with the Agent Framework approach in C#. Uses Microsoft.Agents.AI to create an AIAgent backed by a Foundry model.",
     "language": "csharp",
     "framework": "Agent Framework",
-    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/csharp/hosted-agents/agent-framework/HelloWorld/agent.manifest.yaml",
+    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/csharp/hosted-agents/agent-framework/hello-world/agent.manifest.yaml",
     "tags": ["example", "Responses Protocol"]
-  },
-  {
-    "title": "Foundry Agent",
-    "description": "A hosted agent that delegates to a Foundry-managed agent definition, retrieving the agent by name from the platform.",
-    "language": "csharp",
-    "framework": "Agent Framework",
-    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/csharp/hosted-agents/agent-framework/foundry-agent/agent.manifest.yaml",
-    "tags": ["Foundry Agent", "Responses Protocol"]
   },
   {
     "title": "Invocations Echo Agent",


### PR DESCRIPTION
This pull request makes a small update to the `website/static/agent-templates.json` file by correcting the URL for the Hello World agent example and removing the Foundry Agent template entry. These changes help ensure the accuracy and relevance of the agent templates list.

- Agent template updates:
  * Updated the `source` URL for the Hello World agent to use the correct lowercase path (`hello-world` instead of `HelloWorld`).
  * Removed the "Foundry Agent" template entry, which included its description, language, framework, source URL, and tags.