### PR TITLE
fix cookie banner not showing up

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -57,18 +57,17 @@ const config = {
   ],
 
   // CONFIG: scripts
-  // SECURITY: External scripts use SRI (Subresource Integrity) hashes to prevent
-  // tampering. If a script is updated at the CDN, the hash must be recomputed:
-  //   openssl dgst -sha384 -binary <script> | openssl base64 -A
+  // NOTE: We deliberately do NOT pin SRI integrity hashes on these scripts.
+  // Both URLs are *versionless* (no semver in the path) and Microsoft updates
+  // them in place. A pinned hash on a moving target silently breaks the script
+  // load whenever the CDN is updated
   scripts: [
     {
       src: "https://js.monitor.azure.com/scripts/c/ms.analytics-web-4.min.js",
-      integrity: "sha384-bOZFdvPm/KMmQLFjVrWrLqdeRzrwwPIMm/zUGqwuJwYdUL3OjSQ8SFOCBBIOsVD3",
       crossOrigin: "anonymous",
     },
     {
       src: "https://wcpstatic.microsoft.com/mscc/lib/v2/wcp-consent.js",
-      integrity: "sha384-KjrOYIQAJ7b8Lj+NMikxVZ7DPdSoWFR0hdI3aLBOZ1ZgypozA/whqu48qc1q59sf",
       crossOrigin: "anonymous",
     },
   ],

--- a/website/src/theme/Root.js
+++ b/website/src/theme/Root.js
@@ -78,39 +78,31 @@ const telemetryInit = () => {
       "en-US",
       "cookie-banner",
       function (err, _siteConsent) {
-        if (!err) {
-          siteConsent = _siteConsent;
-        } else {
-          console.log("Error initializing WcpConsent: " + err);
+        if (err) {
+          console.warn("Error initializing WcpConsent: " + err);
+          return;
         }
+        siteConsent = _siteConsent;
+
+        if (siteConsent.isConsentRequired) {
+          var manageCookies = document.getElementById("manage_cookie");
+          if (manageCookies) {
+            manageCookies.addEventListener("click", function (e) {
+              e.preventDefault();
+              siteConsent.manageConsent();
+            });
+          }
+        } else {
+          // Consent confirmed NOT required (non-EU / non-regulated market).
+          // Remove the Manage Cookies link + separator from the footer.
+          removeItem("footer__links_" + manageCookieLabel);
+          removeItem(manageCookieId);
+        }
+
+        setNonEssentialCookies(siteConsent.getConsent());
       },
       onConsentChanged
     );
-
-    if (
-      WcpConsent.siteConsent &&
-      WcpConsent.siteConsent.isConsentRequired
-    ) {
-      var manageCookies = document.getElementById("manage_cookie");
-      if (manageCookies) {
-        manageCookies.addEventListener("click", function (e) {
-          e.preventDefault();
-          WcpConsent.siteConsent.manageConsent();
-        });
-      }
-    } else if (WcpConsent.siteConsent) {
-      // Consent confirmed NOT required (non-EU / non-regulated market).
-      // Remove the Manage Cookies link + separator from the footer.
-      // NOTE: the previous unguarded `else` branch also fired when
-      // WcpConsent itself was undefined, silently wiping the footer link
-      // on every script-load failure. This guard prevents that.
-      removeItem("footer__links_" + manageCookieLabel);
-      removeItem(manageCookieId);
-    }
-
-    if (WcpConsent.siteConsent) {
-      setNonEssentialCookies(WcpConsent.siteConsent.getConsent());
-    }
   }
 
   var wcpInitialized = false;
@@ -179,10 +171,8 @@ const telemetryInit = () => {
       propertyConfiguration: {
         callback: {
           userConsentDetails: function () {
-            var latestSiteConsent =
-              siteConsent || (window.WcpConsent && window.WcpConsent.siteConsent);
-            return latestSiteConsent && latestSiteConsent.getConsent
-              ? latestSiteConsent.getConsent()
+            return siteConsent && siteConsent.getConsent
+              ? siteConsent.getConsent()
               : null;
           },
         },

--- a/website/test/consent-banner.test.ts
+++ b/website/test/consent-banner.test.ts
@@ -71,14 +71,14 @@ describe('EU cookie consent banner wiring', () => {
     test('docusaurus.config.js does NOT pin SRI on the versionless WCP consent script', () => {
         const config = readRepoFile('docusaurus.config.js');
         expect(config).not.toMatch(
-            /wcp-consent\.js[\s\S]{0,200}?integrity:\s*["']sha384-/
+            /wcp-consent\.js[\s\S]{0,200}?integrity\s*:/
         );
     });
 
     test('docusaurus.config.js does NOT pin SRI on the versionless 1DS analytics script', () => {
         const config = readRepoFile('docusaurus.config.js');
         expect(config).not.toMatch(
-            /ms\.analytics-web-4\.min\.js[\s\S]{0,200}?integrity:\s*["']sha384-/
+            /ms\.analytics-web-4\.min\.js[\s\S]{0,200}?integrity\s*:/
         );
     });
 
@@ -159,15 +159,24 @@ describe('EU cookie consent banner wiring', () => {
         expect(root).toMatch(/useEffect\s*\(\s*\(\s*\)\s*=>\s*\{\s*return\s+telemetryInit\s*\(\s*\)\s*;/);
     });
 
-    test('Root does not delete the Manage Cookies link when WcpConsent failed to load', () => {
+    test('Root only removes the Manage Cookies link inside the !isConsentRequired branch', () => {
         const root = readRepoFile('src/theme/Root.js');
         const initBlock = root.match(
             /WcpConsent\.init\s*\([\s\S]*?onConsentChanged\s*\)\s*;/
         );
         expect(initBlock).not.toBeNull();
         const initBody = initBlock![0];
-        expect(initBody).toMatch(/removeItem\s*\(\s*["']footer__links_/);
-        expect(initBody).toMatch(/removeItem\s*\(\s*manageCookieId\s*\)/);
+        const elseBranch = initBody.match(
+            /if\s*\(\s*siteConsent\.isConsentRequired\s*\)\s*\{[\s\S]*?\}\s*else\s*\{([\s\S]*?)\}/
+        );
+        expect(elseBranch).not.toBeNull();
+        const elseBody = elseBranch![1];
+        expect(elseBody).toMatch(/removeItem\s*\(\s*["']footer__links_/);
+        expect(elseBody).toMatch(/removeItem\s*\(\s*manageCookieId\s*\)/);
+        const removeCallSites = (
+            root.match(/removeItem\s*\(/g) || []
+        ).length - (root.match(/function\s+removeItem\s*\(/g) || []).length;
+        expect(removeCallSites).toBe(2);
     });
 
     test('Root reads siteConsent only from the init callback, never from the global', () => {

--- a/website/test/consent-banner.test.ts
+++ b/website/test/consent-banner.test.ts
@@ -68,21 +68,17 @@ describe('EU cookie consent banner wiring', () => {
         );
     });
 
-    test('docusaurus.config.js pins an SRI hash on the WCP consent script entry', () => {
+    test('docusaurus.config.js does NOT pin SRI on the versionless WCP consent script', () => {
         const config = readRepoFile('docusaurus.config.js');
-        // Must include the wcp-consent.js URL AND an integrity pin within
-        // the same scripts[] object. A loose regex that just looks for any
-        // integrity attribute in the file would pass even if the WCP entry
-        // were deleted while the 1DS entry kept its pin.
-        expect(config).toMatch(
-            /wcp-consent\.js[\s\S]{0,200}?integrity:\s*["']sha384-[A-Za-z0-9+/=]+["']/
+        expect(config).not.toMatch(
+            /wcp-consent\.js[\s\S]{0,200}?integrity:\s*["']sha384-/
         );
     });
 
-    test('docusaurus.config.js pins an SRI hash on the 1DS analytics script entry', () => {
+    test('docusaurus.config.js does NOT pin SRI on the versionless 1DS analytics script', () => {
         const config = readRepoFile('docusaurus.config.js');
-        expect(config).toMatch(
-            /ms\.analytics-web-4\.min\.js[\s\S]{0,200}?integrity:\s*["']sha384-[A-Za-z0-9+/=]+["']/
+        expect(config).not.toMatch(
+            /ms\.analytics-web-4\.min\.js[\s\S]{0,200}?integrity:\s*["']sha384-/
         );
     });
 
@@ -164,14 +160,22 @@ describe('EU cookie consent banner wiring', () => {
     });
 
     test('Root does not delete the Manage Cookies link when WcpConsent failed to load', () => {
-        // Regression guard for the bare `else { removeItem(...) }` bug:
-        // if WcpConsent was undefined, the old else branch would execute
-        // anyway and wipe the footer link for every user. The fix narrows
-        // this branch to `else if (WcpConsent.siteConsent)` so the link is
-        // only removed when WCP has positively told us consent is not
-        // required.
         const root = readRepoFile('src/theme/Root.js');
-        expect(root).toMatch(/else\s+if\s*\(\s*WcpConsent\.siteConsent\s*\)/);
+        const initBlock = root.match(
+            /WcpConsent\.init\s*\([\s\S]*?onConsentChanged\s*\)\s*;/
+        );
+        expect(initBlock).not.toBeNull();
+        const initBody = initBlock![0];
+        expect(initBody).toMatch(/removeItem\s*\(\s*["']footer__links_/);
+        expect(initBody).toMatch(/removeItem\s*\(\s*manageCookieId\s*\)/);
+    });
+
+    test('Root reads siteConsent only from the init callback, never from the global', () => {
+        const root = readRepoFile('src/theme/Root.js');
+        const stripped = root
+            .replace(/\/\*[\s\S]*?\*\//g, '')
+            .replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+        expect(stripped).not.toMatch(/WcpConsent\s*\.\s*siteConsent\b/);
     });
 
     test('Navbar Layout no longer owns consent bootstrap', () => {
@@ -214,9 +218,7 @@ function makeWcp(siteConsent: FakeSiteConsent) {
             cb(null, siteConsent);
         }
     );
-    // Match the real wcp-consent.js shape: siteConsent is available on the
-    // global right after init resolves.
-    return { init, siteConsent };
+    return { init };
 }
 
 describe('telemetryInit behavior (jsdom)', () => {


### PR DESCRIPTION
Fix #842 

### Root causes

1. SRI hashes pinned on CDN URLs. docusaurus.config.js pinned sha384 integrity hashes on:
 - https://js.monitor.azure.com/scripts/c/ms.analytics-web-4.min.js
 - https://wcpstatic.microsoft.com/mscc/lib/v2/wcp-consent.js
Whenever the CDN is updated, the pinned hash no longer matches and browsers silently block the script — window.WcpConsent never appears and the banner never renders. 

2. siteConsent read from a non-existent global. Root.js read WcpConsent.siteConsent.isConsentRequired, .manageConsent(), and .getConsent() synchronously after WcpConsent.init(...) returned. WCP v2 only exposes siteConsent via the second argument of the init callback — there is no WcpConsent.siteConsent global. Every read returned undefined, silently skipping the manage-cookie click wiring and the consent-gated cookie setup. This is why the Manage Cookies link did nothing.

### Verification

 - npm test — 373/373 passing (11 suites).
 - npm run build — succeeds.
 - Manually verified the rebuilt site against an EU remote desktop via a Cloudflare quick tunnel: banner renders and Manage Cookies open the consent modal.