### PR TITLE
Add "featured" and "recommended" tags to various agent templates

### DIFF
--- a/website/static/templates.json
+++ b/website/static/templates.json
@@ -7304,6 +7304,7 @@
     "extensionFramework": "Agent Framework",
     "extensionTags": [
       "local tools",
+      "template",
       "Responses Protocol"
     ]
   },
@@ -7321,6 +7322,7 @@
     "extensionFramework": "Agent Framework",
     "extensionTags": [
       "MCP",
+      "template",
       "Responses Protocol"
     ]
   },
@@ -7443,6 +7445,8 @@
     "extensionFramework": "Bring Your Own",
     "extensionTags": [
       "example",
+      "template",
+      "recommended",
       "Responses Protocol"
     ]
   },
@@ -7460,6 +7464,7 @@
     "extensionFramework": "Bring Your Own",
     "extensionTags": [
       "background mode",
+      "template",
       "Responses Protocol"
     ]
   },
@@ -7477,6 +7482,7 @@
     "extensionFramework": "Bring Your Own",
     "extensionTags": [
       "function calling",
+      "template",
       "Responses Protocol"
     ]
   },
@@ -7528,6 +7534,7 @@
     "extensionFramework": "Agent Framework",
     "extensionTags": [
       "local tools",
+      "template",
       "Responses Protocol"
     ]
   },
@@ -7545,6 +7552,7 @@
     "extensionFramework": "Agent Framework",
     "extensionTags": [
       "MCP",
+      "template",
       "Responses Protocol"
     ]
   },
@@ -7562,6 +7570,7 @@
     "extensionFramework": "Agent Framework",
     "extensionTags": [
       "Foundry Toolbox",
+      "template",
       "Responses Protocol"
     ]
   },
@@ -7614,6 +7623,7 @@
     "extensionFramework": "Bring Your Own",
     "extensionTags": [
       "GitHub Copilot SDK",
+      "template",
       "Invocations Protocol"
     ]
   },
@@ -7718,6 +7728,7 @@
     "extensionFramework": "Bring Your Own",
     "extensionTags": [
       "background mode",
+      "template",
       "Responses Protocol"
     ]
   },
@@ -7735,6 +7746,8 @@
     "extensionFramework": "Bring Your Own",
     "extensionTags": [
       "example",
+      "template",
+      "recommended",
       "Responses Protocol"
     ]
   },
@@ -7770,6 +7783,7 @@
     "extensionFramework": "Bring Your Own",
     "extensionTags": [
       "function calling",
+      "template",
       "Responses Protocol"
     ]
   },
@@ -7787,6 +7801,7 @@
     "extensionFramework": "Bring Your Own",
     "extensionTags": [
       "Foundry Toolbox",
+      "template",
       "Responses Protocol"
     ]
   }

--- a/website/static/templates.json
+++ b/website/static/templates.json
@@ -7257,7 +7257,7 @@
     "id": "9fa7012a-4961-46d0-abc9-db9a8ea49f06"
   },
   {
-    "title": "Hello World agent (Responses, Agent Framework)",
+    "title": "Hello World agent (Responses, Agent Framework, C#)",
     "description": "Minimal Hello World agent using the Responses protocol with the Agent Framework approach in C#. Uses Microsoft.Agents.AI to create an AIAgent backed by a Foundry model.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7274,7 +7274,7 @@
     ]
   },
   {
-    "title": "Echo agent (Invocations, Agent Framework)",
+    "title": "Echo agent (Invocations, Agent Framework, C#)",
     "description": "A minimal echo agent hosted as a Foundry Hosted Agent using the Invocations protocol and the Agent Framework. No LLM or Azure credentials required.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7291,7 +7291,7 @@
     ]
   },
   {
-    "title": "Agent with Local Tools (Responses, Agent Framework)",
+    "title": "Agent with Local Tools (Responses, Agent Framework, C#)",
     "description": "A travel assistant agent with local C# function tools for hotel search in Seattle.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7309,7 +7309,7 @@
     ]
   },
   {
-    "title": "Agent with MCP Tools (Responses, Agent Framework)",
+    "title": "Agent with MCP Tools (Responses, Agent Framework, C#)",
     "description": "A developer assistant with remote MCP tools connecting to GitHub and Microsoft Learn documentation servers.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7327,7 +7327,7 @@
     ]
   },
   {
-    "title": "Simple agent (Responses, Agent Framework)",
+    "title": "Simple agent (Responses, Agent Framework, C#)",
     "description": "A simple general-purpose AI assistant hosted as a Foundry Hosted Agent using the Agent Framework.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7344,7 +7344,7 @@
     ]
   },
   {
-    "title": "Text Search RAG agent (Responses, Agent Framework)",
+    "title": "Text Search RAG agent (Responses, Agent Framework, C#)",
     "description": "A support specialist agent with RAG capabilities using TextSearchProvider to ground answers in product documentation.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7362,7 +7362,7 @@
     ]
   },
   {
-    "title": "Translation Workflow agent (Responses, Agent Framework)",
+    "title": "Translation Workflow agent (Responses, Agent Framework, C#)",
     "description": "A workflow agent that performs sequential translation through multiple languages (English to French to Spanish to English).",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7380,7 +7380,7 @@
     ]
   },
   {
-    "title": "Hello World agent (Invocations)",
+    "title": "Hello World agent (Invocations, C#)",
     "description": "Minimal Hello World agent using the Invocations protocol with a bring-your-own approach in C#. Calls a Foundry model via the Responses API and returns the response as a streaming SSE event stream.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7397,7 +7397,7 @@
     ]
   },
   {
-    "title": "Human-in-the-Loop agent (Invocations)",
+    "title": "Human-in-the-Loop agent (Invocations, C#)",
     "description": "A human-in-the-loop agent that demonstrates the approval-gate pattern using the Azure.AI.AgentServer.Invocations SDK with Azure OpenAI.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7415,7 +7415,7 @@
     ]
   },
   {
-    "title": "Note-taking agent (Invocations)",
+    "title": "Note-taking agent (Invocations, C#)",
     "description": "A note-taking agent using the Invocations protocol with Azure OpenAI function calling in C#. Demonstrates tool use with per-session JSONL persistence and SSE streaming.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7432,7 +7432,7 @@
     ]
   },
   {
-    "title": "Hello World agent (Responses)",
+    "title": "Hello World agent (Responses, C#)",
     "description": "Minimal Hello World agent using the Responses protocol with a bring-your-own approach in C#. Calls a Foundry model via the Responses API and returns the response.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7451,7 +7451,7 @@
     ]
   },
   {
-    "title": "Background agent (Responses)",
+    "title": "Background agent (Responses, C#)",
     "description": "A long-running research agent that demonstrates the background execution pattern using the Azure.AI.AgentServer.Responses SDK with Azure OpenAI.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7469,7 +7469,7 @@
     ]
   },
   {
-    "title": "Note-taking agent (Responses)",
+    "title": "Note-taking agent (Responses, C#)",
     "description": "A note-taking agent using the Responses protocol with Azure OpenAI function calling in C#. Demonstrates tool use with per-session JSONL persistence.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7487,7 +7487,7 @@
     ]
   },
   {
-    "title": "Basic agent (Invocations, Agent Framework)",
+    "title": "Basic agent (Invocations, Agent Framework, Python)",
     "description": "A basic Agent Framework agent hosted by Foundry using the Invocations protocol.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7504,7 +7504,7 @@
     ]
   },
   {
-    "title": "Basic agent (Responses, Agent Framework)",
+    "title": "Basic agent (Responses, Agent Framework, Python)",
     "description": "A basic Agent Framework agent hosted by Foundry using the Responses protocol.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7521,7 +7521,7 @@
     ]
   },
   {
-    "title": "Agent with Local Tools (Responses, Agent Framework)",
+    "title": "Agent with Local Tools (Responses, Agent Framework, Python)",
     "description": "An Agent Framework agent with local tools hosted by Foundry.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7539,7 +7539,7 @@
     ]
   },
   {
-    "title": "Agent with MCP Tools (Responses, Agent Framework)",
+    "title": "Agent with MCP Tools (Responses, Agent Framework, Python)",
     "description": "An Agent Framework agent with remote MCP tools hosted by Foundry.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7557,7 +7557,7 @@
     ]
   },
   {
-    "title": "Agent with Foundry Toolbox (Responses, Agent Framework)",
+    "title": "Agent with Foundry Toolbox (Responses, Agent Framework, Python)",
     "description": "An Agent Framework agent with Foundry Toolbox integration.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7574,7 +7574,7 @@
     ]
   },
   {
-    "title": "Workflow agent (Responses, Agent Framework)",
+    "title": "Workflow agent (Responses, Agent Framework, Python)",
     "description": "An Agent Framework workflow hosted by Foundry.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7591,7 +7591,7 @@
     ]
   },
   {
-    "title": "Agent with AG-UI (Invocations, Pydantic AI, AG-UI)",
+    "title": "Agent with AG-UI (Invocations, Pydantic AI, AG-UI, Python)",
     "description": "AG-UI protocol over Foundry invocations using Pydantic AI with Azure OpenAI. Streams standard AG-UI events with zero manual event translation.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7609,7 +7609,7 @@
     ]
   },
   {
-    "title": "Agent with Copilot SDK (Invocations, GitHub Copilot SDK)",
+    "title": "Agent with Copilot SDK (Invocations, GitHub Copilot SDK, Python)",
     "description": "A getting-started agent that uses the GitHub Copilot SDK with the azure-ai-agentserver-invocations protocol, streaming raw session events as SSE.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7627,7 +7627,7 @@
     ]
   },
   {
-    "title": "Hello World agent (Invocations)",
+    "title": "Hello World agent (Invocations, Python)",
     "description": "Minimal Hello World agent using the Invocations protocol with a bring-your-own approach. Calls a Foundry model via the Responses API and returns the response as a streaming SSE event stream.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7644,7 +7644,7 @@
     ]
   },
   {
-    "title": "Human-in-the-Loop agent (Invocations)",
+    "title": "Human-in-the-Loop agent (Invocations, Python)",
     "description": "A human-in-the-loop agent that demonstrates the approval-gate pattern using the azure-ai-agentserver-invocations SDK.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7662,7 +7662,7 @@
     ]
   },
   {
-    "title": "LangGraph Chat agent (Invocations, LangGraph)",
+    "title": "LangGraph Chat agent (Invocations, LangGraph, Python)",
     "description": "Multi-turn chat agent built with LangGraph and the Invocations protocol. Demonstrates a tool-calling agent graph with get_current_time and calculator tools.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7680,7 +7680,7 @@
     ]
   },
   {
-    "title": "Note-taking agent (Invocations)",
+    "title": "Note-taking agent (Invocations, Python)",
     "description": "Note-taking agent using the Invocations protocol. Demonstrates function calling (save_note/get_notes tools) with per-session JSONL persistence and SSE streaming.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7697,7 +7697,7 @@
     ]
   },
   {
-    "title": "Agent with Foundry Toolbox (Invocations)",
+    "title": "Agent with Foundry Toolbox (Invocations, Python)",
     "description": "Bring-your-own agent using the Invocations protocol with Foundry Toolbox MCP integration. Connects to a toolbox at startup, discovers tools, and lets the model call them during conversation.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7714,7 +7714,7 @@
     ]
   },
   {
-    "title": "Background agent (Responses)",
+    "title": "Background agent (Responses, Python)",
     "description": "A long-running agent that demonstrates the background execution pattern using the azure-ai-agentserver-responses SDK. Supports polling and cancellation.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7732,7 +7732,7 @@
     ]
   },
   {
-    "title": "Hello World agent (Responses)",
+    "title": "Hello World agent (Responses, Python)",
     "description": "Minimal Hello World agent using the Responses protocol with a bring-your-own approach. Calls a Foundry model via the Responses API and returns the response.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7751,7 +7751,7 @@
     ]
   },
   {
-    "title": "LangGraph Chat agent (Responses, LangGraph)",
+    "title": "LangGraph Chat agent (Responses, LangGraph, Python)",
     "description": "Multi-turn chat agent built with LangGraph using the Responses protocol. Demonstrates a tool-calling agent graph with server-side conversation state.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7769,7 +7769,7 @@
     ]
   },
   {
-    "title": "Note-taking agent (Responses)",
+    "title": "Note-taking agent (Responses, Python)",
     "description": "Note-taking agent using the Responses protocol. Demonstrates function calling (save_note/get_notes tools) with per-session JSONL persistence and streaming responses.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7787,7 +7787,7 @@
     ]
   },
   {
-    "title": "Agent with Foundry Toolbox (Responses)",
+    "title": "Agent with Foundry Toolbox (Responses, Python)",
     "description": "Bring-your-own agent using the Responses protocol with Foundry Toolbox MCP integration. Connects to a toolbox at startup, discovers tools, and lets the model call them during conversation.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",

--- a/website/static/templates.json
+++ b/website/static/templates.json
@@ -7257,7 +7257,7 @@
     "id": "9fa7012a-4961-46d0-abc9-db9a8ea49f06"
   },
   {
-    "title": "Hello World (.NET, Agent Framework)",
+    "title": "Hello World agent (Responses, Agent Framework)",
     "description": "Minimal Hello World agent using the Responses protocol with the Agent Framework approach in C#. Uses Microsoft.Agents.AI to create an AIAgent backed by a Foundry model.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7274,7 +7274,7 @@
     ]
   },
   {
-    "title": "Invocations Echo Agent",
+    "title": "Echo agent (Invocations, Agent Framework)",
     "description": "A minimal echo agent hosted as a Foundry Hosted Agent using the Invocations protocol and the Agent Framework. No LLM or Azure credentials required.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7291,7 +7291,7 @@
     ]
   },
   {
-    "title": "Local Tools Agent",
+    "title": "Agent with Local Tools (Responses, Agent Framework)",
     "description": "A travel assistant agent with local C# function tools for hotel search in Seattle.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7304,12 +7304,12 @@
     "extensionFramework": "Agent Framework",
     "extensionTags": [
       "local tools",
-      "template",
+      "featured",
       "Responses Protocol"
     ]
   },
   {
-    "title": "MCP Tools Agent",
+    "title": "Agent with MCP Tools (Responses, Agent Framework)",
     "description": "A developer assistant with remote MCP tools connecting to GitHub and Microsoft Learn documentation servers.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7322,12 +7322,12 @@
     "extensionFramework": "Agent Framework",
     "extensionTags": [
       "MCP",
-      "template",
+      "featured",
       "Responses Protocol"
     ]
   },
   {
-    "title": "Simple Agent",
+    "title": "Simple agent (Responses, Agent Framework)",
     "description": "A simple general-purpose AI assistant hosted as a Foundry Hosted Agent using the Agent Framework.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7344,7 +7344,7 @@
     ]
   },
   {
-    "title": "Text Search RAG Agent",
+    "title": "Text Search RAG agent (Responses, Agent Framework)",
     "description": "A support specialist agent with RAG capabilities using TextSearchProvider to ground answers in product documentation.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7362,7 +7362,7 @@
     ]
   },
   {
-    "title": "Translation Workflow Agent",
+    "title": "Translation Workflow agent (Responses, Agent Framework)",
     "description": "A workflow agent that performs sequential translation through multiple languages (English to French to Spanish to English).",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7380,7 +7380,7 @@
     ]
   },
   {
-    "title": "Hello World (.NET, Invocations)",
+    "title": "Hello World agent (Invocations)",
     "description": "Minimal Hello World agent using the Invocations protocol with a bring-your-own approach in C#. Calls a Foundry model via the Responses API and returns the response as a streaming SSE event stream.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7397,7 +7397,7 @@
     ]
   },
   {
-    "title": "Human-in-the-Loop (.NET, Invocations)",
+    "title": "Human-in-the-Loop agent (Invocations)",
     "description": "A human-in-the-loop agent that demonstrates the approval-gate pattern using the Azure.AI.AgentServer.Invocations SDK with Azure OpenAI.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7415,7 +7415,7 @@
     ]
   },
   {
-    "title": "Notetaking Agent (.NET, Invocations)",
+    "title": "Note-taking agent (Invocations)",
     "description": "A note-taking agent using the Invocations protocol with Azure OpenAI function calling in C#. Demonstrates tool use with per-session JSONL persistence and SSE streaming.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7432,7 +7432,7 @@
     ]
   },
   {
-    "title": "Hello World (.NET, Responses)",
+    "title": "Hello World agent (Responses)",
     "description": "Minimal Hello World agent using the Responses protocol with a bring-your-own approach in C#. Calls a Foundry model via the Responses API and returns the response.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7445,13 +7445,13 @@
     "extensionFramework": "Bring Your Own",
     "extensionTags": [
       "example",
-      "template",
+      "featured",
       "recommended",
       "Responses Protocol"
     ]
   },
   {
-    "title": "Background Agent (.NET, Responses)",
+    "title": "Background agent (Responses)",
     "description": "A long-running research agent that demonstrates the background execution pattern using the Azure.AI.AgentServer.Responses SDK with Azure OpenAI.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7464,12 +7464,12 @@
     "extensionFramework": "Bring Your Own",
     "extensionTags": [
       "background mode",
-      "template",
+      "featured",
       "Responses Protocol"
     ]
   },
   {
-    "title": "Notetaking Agent (.NET, Responses)",
+    "title": "Note-taking agent (Responses)",
     "description": "A note-taking agent using the Responses protocol with Azure OpenAI function calling in C#. Demonstrates tool use with per-session JSONL persistence.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7482,12 +7482,12 @@
     "extensionFramework": "Bring Your Own",
     "extensionTags": [
       "function calling",
-      "template",
+      "featured",
       "Responses Protocol"
     ]
   },
   {
-    "title": "Basic Agent (Invocations)",
+    "title": "Basic agent (Invocations, Agent Framework)",
     "description": "A basic Agent Framework agent hosted by Foundry using the Invocations protocol.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7504,7 +7504,7 @@
     ]
   },
   {
-    "title": "Basic Agent (Responses)",
+    "title": "Basic agent (Responses, Agent Framework)",
     "description": "A basic Agent Framework agent hosted by Foundry using the Responses protocol.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7521,7 +7521,7 @@
     ]
   },
   {
-    "title": "Agent with Local Tools (Responses)",
+    "title": "Agent with Local Tools (Responses, Agent Framework)",
     "description": "An Agent Framework agent with local tools hosted by Foundry.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7534,12 +7534,12 @@
     "extensionFramework": "Agent Framework",
     "extensionTags": [
       "local tools",
-      "template",
+      "featured",
       "Responses Protocol"
     ]
   },
   {
-    "title": "Agent with Remote MCP Tools",
+    "title": "Agent with MCP Tools (Responses, Agent Framework)",
     "description": "An Agent Framework agent with remote MCP tools hosted by Foundry.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7552,12 +7552,12 @@
     "extensionFramework": "Agent Framework",
     "extensionTags": [
       "MCP",
-      "template",
+      "featured",
       "Responses Protocol"
     ]
   },
   {
-    "title": "Agent with Foundry Toolbox",
+    "title": "Agent with Foundry Toolbox (Responses, Agent Framework)",
     "description": "An Agent Framework agent with Foundry Toolbox integration.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7570,12 +7570,11 @@
     "extensionFramework": "Agent Framework",
     "extensionTags": [
       "Foundry Toolbox",
-      "template",
       "Responses Protocol"
     ]
   },
   {
-    "title": "Workflow Agent",
+    "title": "Workflow agent (Responses, Agent Framework)",
     "description": "An Agent Framework workflow hosted by Foundry.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7592,7 +7591,7 @@
     ]
   },
   {
-    "title": "AG-UI (Invocations)",
+    "title": "Agent with AG-UI (Invocations, Pydantic AI, AG-UI)",
     "description": "AG-UI protocol over Foundry invocations using Pydantic AI with Azure OpenAI. Streams standard AG-UI events with zero manual event translation.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7610,7 +7609,7 @@
     ]
   },
   {
-    "title": "GitHub Copilot (Invocations)",
+    "title": "Agent with Copilot SDK (Invocations, GitHub Copilot SDK)",
     "description": "A getting-started agent that uses the GitHub Copilot SDK with the azure-ai-agentserver-invocations protocol, streaming raw session events as SSE.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7623,12 +7622,12 @@
     "extensionFramework": "Bring Your Own",
     "extensionTags": [
       "GitHub Copilot SDK",
-      "template",
+      "featured",
       "Invocations Protocol"
     ]
   },
   {
-    "title": "Hello World (Python, Invocations)",
+    "title": "Hello World agent (Invocations)",
     "description": "Minimal Hello World agent using the Invocations protocol with a bring-your-own approach. Calls a Foundry model via the Responses API and returns the response as a streaming SSE event stream.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7645,7 +7644,7 @@
     ]
   },
   {
-    "title": "Human-in-the-Loop (Invocations)",
+    "title": "Human-in-the-Loop agent (Invocations)",
     "description": "A human-in-the-loop agent that demonstrates the approval-gate pattern using the azure-ai-agentserver-invocations SDK.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7663,7 +7662,7 @@
     ]
   },
   {
-    "title": "LangGraph Chat (Invocations)",
+    "title": "LangGraph Chat agent (Invocations, LangGraph)",
     "description": "Multi-turn chat agent built with LangGraph and the Invocations protocol. Demonstrates a tool-calling agent graph with get_current_time and calculator tools.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7681,7 +7680,7 @@
     ]
   },
   {
-    "title": "Notetaking Agent (Invocations)",
+    "title": "Note-taking agent (Invocations)",
     "description": "Note-taking agent using the Invocations protocol. Demonstrates function calling (save_note/get_notes tools) with per-session JSONL persistence and SSE streaming.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7698,7 +7697,7 @@
     ]
   },
   {
-    "title": "Toolbox (Python, Invocations)",
+    "title": "Agent with Foundry Toolbox (Invocations)",
     "description": "Bring-your-own agent using the Invocations protocol with Foundry Toolbox MCP integration. Connects to a toolbox at startup, discovers tools, and lets the model call them during conversation.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7715,7 +7714,7 @@
     ]
   },
   {
-    "title": "Background Agent (Responses)",
+    "title": "Background agent (Responses)",
     "description": "A long-running agent that demonstrates the background execution pattern using the azure-ai-agentserver-responses SDK. Supports polling and cancellation.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7728,12 +7727,12 @@
     "extensionFramework": "Bring Your Own",
     "extensionTags": [
       "background mode",
-      "template",
+      "featured",
       "Responses Protocol"
     ]
   },
   {
-    "title": "Hello World (Python, Responses)",
+    "title": "Hello World agent (Responses)",
     "description": "Minimal Hello World agent using the Responses protocol with a bring-your-own approach. Calls a Foundry model via the Responses API and returns the response.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7746,13 +7745,13 @@
     "extensionFramework": "Bring Your Own",
     "extensionTags": [
       "example",
-      "template",
+      "featured",
       "recommended",
       "Responses Protocol"
     ]
   },
   {
-    "title": "LangGraph Chat (Responses)",
+    "title": "LangGraph Chat agent (Responses, LangGraph)",
     "description": "Multi-turn chat agent built with LangGraph using the Responses protocol. Demonstrates a tool-calling agent graph with server-side conversation state.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7770,7 +7769,7 @@
     ]
   },
   {
-    "title": "Notetaking Agent (Responses)",
+    "title": "Note-taking agent (Responses)",
     "description": "Note-taking agent using the Responses protocol. Demonstrates function calling (save_note/get_notes tools) with per-session JSONL persistence and streaming responses.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7783,12 +7782,12 @@
     "extensionFramework": "Bring Your Own",
     "extensionTags": [
       "function calling",
-      "template",
+      "featured",
       "Responses Protocol"
     ]
   },
   {
-    "title": "Toolbox (Python, Responses)",
+    "title": "Agent with Foundry Toolbox (Responses)",
     "description": "Bring-your-own agent using the Responses protocol with Foundry Toolbox MCP integration. Connects to a toolbox at startup, discovers tools, and lets the model call them during conversation.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7801,7 +7800,7 @@
     "extensionFramework": "Bring Your Own",
     "extensionTags": [
       "Foundry Toolbox",
-      "template",
+      "featured",
       "Responses Protocol"
     ]
   }

--- a/website/static/templates.json
+++ b/website/static/templates.json
@@ -7270,7 +7270,9 @@
     "extensionFramework": "Agent Framework",
     "extensionTags": [
       "example",
-      "Responses Protocol"
+      "Responses Protocol",
+      "recommended",
+      "featured"
     ]
   },
   {
@@ -7380,7 +7382,7 @@
     ]
   },
   {
-    "title": "Hello World agent (Invocations, C#)",
+    "title": "Hello World agent (Invocations, without a framework, C#)",
     "description": "Minimal Hello World agent using the Invocations protocol with a bring-your-own approach in C#. Calls a Foundry model via the Responses API and returns the response as a streaming SSE event stream.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7393,11 +7395,12 @@
     "extensionFramework": "Bring Your Own",
     "extensionTags": [
       "example",
-      "Invocations Protocol"
+      "Invocations Protocol",
+      "featured"
     ]
   },
   {
-    "title": "Human-in-the-Loop agent (Invocations, C#)",
+    "title": "Human-in-the-Loop agent (Invocations, without a framework, C#)",
     "description": "A human-in-the-loop agent that demonstrates the approval-gate pattern using the Azure.AI.AgentServer.Invocations SDK with Azure OpenAI.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7415,7 +7418,7 @@
     ]
   },
   {
-    "title": "Note-taking agent (Invocations, C#)",
+    "title": "Note-taking agent (Invocations, without a framework, C#)",
     "description": "A note-taking agent using the Invocations protocol with Azure OpenAI function calling in C#. Demonstrates tool use with per-session JSONL persistence and SSE streaming.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7432,7 +7435,7 @@
     ]
   },
   {
-    "title": "Hello World agent (Responses, C#)",
+    "title": "Hello World agent (Responses, without a framework, C#)",
     "description": "Minimal Hello World agent using the Responses protocol with a bring-your-own approach in C#. Calls a Foundry model via the Responses API and returns the response.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7445,13 +7448,11 @@
     "extensionFramework": "Bring Your Own",
     "extensionTags": [
       "example",
-      "featured",
-      "recommended",
       "Responses Protocol"
     ]
   },
   {
-    "title": "Background agent (Responses, C#)",
+    "title": "Background agent (Responses, without a framework, C#)",
     "description": "A long-running research agent that demonstrates the background execution pattern using the Azure.AI.AgentServer.Responses SDK with Azure OpenAI.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7464,12 +7465,11 @@
     "extensionFramework": "Bring Your Own",
     "extensionTags": [
       "background mode",
-      "featured",
       "Responses Protocol"
     ]
   },
   {
-    "title": "Note-taking agent (Responses, C#)",
+    "title": "Note-taking agent (Responses, without a framework, C#)",
     "description": "A note-taking agent using the Responses protocol with Azure OpenAI function calling in C#. Demonstrates tool use with per-session JSONL persistence.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7570,7 +7570,8 @@
     "extensionFramework": "Agent Framework",
     "extensionTags": [
       "Foundry Toolbox",
-      "Responses Protocol"
+      "Responses Protocol",
+      "featured"
     ]
   },
   {
@@ -7622,12 +7623,11 @@
     "extensionFramework": "Bring Your Own",
     "extensionTags": [
       "GitHub Copilot SDK",
-      "featured",
       "Invocations Protocol"
     ]
   },
   {
-    "title": "Hello World agent (Invocations, Python)",
+    "title": "Hello World agent (Invocations, without a framework, Python)",
     "description": "Minimal Hello World agent using the Invocations protocol with a bring-your-own approach. Calls a Foundry model via the Responses API and returns the response as a streaming SSE event stream.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7640,11 +7640,12 @@
     "extensionFramework": "Bring Your Own",
     "extensionTags": [
       "example",
-      "Invocations Protocol"
+      "Invocations Protocol",
+      "featured"
     ]
   },
   {
-    "title": "Human-in-the-Loop agent (Invocations, Python)",
+    "title": "Human-in-the-Loop agent (Invocations, without a framework, Python)",
     "description": "A human-in-the-loop agent that demonstrates the approval-gate pattern using the azure-ai-agentserver-invocations SDK.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7680,7 +7681,7 @@
     ]
   },
   {
-    "title": "Note-taking agent (Invocations, Python)",
+    "title": "Note-taking agent (Invocations, without a framework, Python)",
     "description": "Note-taking agent using the Invocations protocol. Demonstrates function calling (save_note/get_notes tools) with per-session JSONL persistence and SSE streaming.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7697,7 +7698,7 @@
     ]
   },
   {
-    "title": "Agent with Foundry Toolbox (Invocations, Python)",
+    "title": "Agent with Foundry Toolbox (Invocations, without a framework, Python)",
     "description": "Bring-your-own agent using the Invocations protocol with Foundry Toolbox MCP integration. Connects to a toolbox at startup, discovers tools, and lets the model call them during conversation.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7714,7 +7715,7 @@
     ]
   },
   {
-    "title": "Background agent (Responses, Python)",
+    "title": "Background agent (Responses, without a framework, Python)",
     "description": "A long-running agent that demonstrates the background execution pattern using the azure-ai-agentserver-responses SDK. Supports polling and cancellation.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7727,12 +7728,11 @@
     "extensionFramework": "Bring Your Own",
     "extensionTags": [
       "background mode",
-      "featured",
       "Responses Protocol"
     ]
   },
   {
-    "title": "Hello World agent (Responses, Python)",
+    "title": "Hello World agent (Responses, without a framework, Python)",
     "description": "Minimal Hello World agent using the Responses protocol with a bring-your-own approach. Calls a Foundry model via the Responses API and returns the response.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7769,7 +7769,7 @@
     ]
   },
   {
-    "title": "Note-taking agent (Responses, Python)",
+    "title": "Note-taking agent (Responses, without a framework, Python)",
     "description": "Note-taking agent using the Responses protocol. Demonstrates function calling (save_note/get_notes tools) with per-session JSONL persistence and streaming responses.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7787,7 +7787,7 @@
     ]
   },
   {
-    "title": "Agent with Foundry Toolbox (Responses, Python)",
+    "title": "Agent with Foundry Toolbox (Responses, without a framework, Python)",
     "description": "Bring-your-own agent using the Responses protocol with Foundry Toolbox MCP integration. Connects to a toolbox at startup, discovers tools, and lets the model call them during conversation.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
@@ -7800,7 +7800,6 @@
     "extensionFramework": "Bring Your Own",
     "extensionTags": [
       "Foundry Toolbox",
-      "featured",
       "Responses Protocol"
     ]
   }


### PR DESCRIPTION
This pull request updates the `website/static/templates.json` file to improve template discoverability and clarity. The main changes include standardizing template titles for consistency, adding more descriptive information (such as protocol, framework, and language) to titles, and tagging select templates as "featured" or "recommended" to highlight them in the UI.

**Template title and metadata improvements:**

* Standardized and clarified template titles to consistently include protocol, framework, and language (e.g., "Hello World agent (Responses, Agent Framework, C#)" instead of "Hello World (.NET, Agent Framework)"). [[1]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139L7260-R7260) [[2]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139L7277-R7277) [[3]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139L7294-R7294) [[4]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139R7307-R7312) [[5]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139R7325-R7330) [[6]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139L7345-R7347) [[7]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139L7363-R7365) [[8]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139L7381-R7383) [[9]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139L7398-R7400) [[10]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139L7416-R7418) [[11]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139L7433-R7435) [[12]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139R7448-R7454) [[13]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139R7467-R7472) [[14]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139R7485-R7490) [[15]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139L7501-R7507) [[16]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139L7518-R7524) [[17]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139R7537-R7542) [[18]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139R7555-R7560) [[19]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139L7569-R7577) [[20]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139L7586-R7594) [[21]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139L7604-R7612) [[22]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139R7625-R7630) [[23]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139L7638-R7647) [[24]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139L7656-R7665) [[25]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139L7674-R7683) [[26]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139L7691-R7700) [[27]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139L7708-R7717) [[28]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139R7730-R7735) [[29]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139R7748-R7754) [[30]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139L7760-R7772) [[31]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139R7785-R7790) [[32]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139R7803)

**Featured and recommended tags:**

* Added `"featured"` and, where appropriate, `"recommended"` tags to the `extensionTags` of select templates to highlight them in the UI and help users find key examples more easily. [[1]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139R7307-R7312) [[2]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139R7325-R7330) [[3]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139R7448-R7454) [[4]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139R7467-R7472) [[5]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139R7485-R7490) [[6]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139R7537-R7542) [[7]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139R7555-R7560) [[8]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139R7625-R7630) [[9]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139R7730-R7735) [[10]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139R7748-R7754) [[11]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139R7785-R7790) [[12]](diffhunk://#diff-62d8af76ca3a1474bb229cd5abef76c9ee89186c8ea4a67c39edb7dc59ffd139R7803)

No functional code changes were made; these updates are limited to improving the clarity, consistency, and discoverability of template metadata for users.