### PR TITLE
Revert Pages actions v4->v5 in release.yml to fix broken prod deploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,9 +47,9 @@ jobs:
         run: |
           npm test
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b  # v4.0.0
         with:
           path: ./website/build
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5.0.0
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4.0.5


### PR DESCRIPTION
## Summary

Revert `actions/upload-pages-artifact` and `actions/deploy-pages` from **v5** back to **v4** in `release.yml`.

## Why

The v4 → v5 bump introduced in #876 broke the production deploy. After PR #876 merged, the live site at https://azure.github.io/awesome-azd/ began serving the raw `README.md` (Jekyll-rendered) instead of the Docusaurus gallery, even though the `Release Awesome Azd` workflow continues to report green.

Root cause:

- `actions/upload-pages-artifact@v5` updated its internal dependency to `actions/upload-artifact@v7` (per its release notes: *"Update upload-artifact action to version 7"*).
- `upload-artifact@v7` produces artifacts using the new immutable-artifacts API.
- `actions/deploy-pages@v5` was not updated to consume that new format — its release notes are limited to a Node.js 24 bump and small chores.
- Net effect: the upload step appears to succeed, the deploy step appears to succeed, but the artifact GitHub Pages actually serves is empty/incorrect, so Pages falls back to whatever exists at the configured branch source — i.e., the source tree that `sync-gh-pages.yml` force-pushes to `gh-pages` — which Jekyll renders as `README.md`.

## Change

```diff
-        uses: actions/upload-pages-artifact@fc324d35…  # v5.0.0
+        uses: actions/upload-pages-artifact@7b1f4a76…  # v4.0.0
...
-        uses: actions/deploy-pages@cd2ce8fc…           # v5.0.0
+        uses: actions/deploy-pages@d6db9016…           # v4.0.5
```

Both pinned by SHA. Other action bumps from #876 (checkout v6.0.2, setup-node v6.4.0) are kept.

## Validation

- After merge, dispatch `Release Awesome Azd` on `gh-pages` and verify https://azure.github.io/awesome-azd/ renders the gallery (not the README).
- Re-upgrade to v5 once `actions/deploy-pages` ships a release that aligns with `upload-artifact@v7`.
