### PR TITLE
Add CI check to validate template source URLs

### DIFF
--- a/.github/scripts/validate-template-sources.js
+++ b/.github/scripts/validate-template-sources.js
@@ -1,0 +1,129 @@
+/**
+ * Validate that every `source` URL in templates.json and agent-templates.json
+ * resolves to a 2xx response. Designed to catch silent breakage when upstream
+ * sample repos rename or remove files we reference.
+ *
+ * Output: writes broken-sources.md and exits non-zero if FAIL_ON_BROKEN=true
+ * and any URL is non-2xx. Always appends a summary to $GITHUB_STEP_SUMMARY.
+ */
+const fs = require('fs');
+const { validateUrl } = require('./url-validation');
+
+const MANIFEST_FILES = [
+  'website/static/templates.json',
+  'website/static/agent-templates.json',
+];
+
+const CONCURRENCY = 8;
+const TIMEOUT_MS = 15_000;
+const RETRIES = 2;
+
+const failOnBroken = (process.env.FAIL_ON_BROKEN || 'true').toLowerCase() === 'true';
+
+async function probe(url) {
+  validateUrl(url, 'template source'); // SSRF guard via shared util
+
+  let lastErr;
+  for (let attempt = 0; attempt <= RETRIES; attempt++) {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+    try {
+      // HEAD first; fall back to GET if the host rejects HEAD.
+      let res = await fetch(url, { method: 'HEAD', signal: ctrl.signal, redirect: 'follow' });
+      if (res.status === 403 || res.status === 405) {
+        res = await fetch(url, { method: 'GET', signal: ctrl.signal, redirect: 'follow' });
+      }
+      clearTimeout(timer);
+      return { url, status: res.status, ok: res.ok };
+    } catch (err) {
+      clearTimeout(timer);
+      lastErr = err;
+      if (attempt < RETRIES) {
+        await new Promise((r) => setTimeout(r, 500 * (attempt + 1)));
+      }
+    }
+  }
+  return { url, status: 0, ok: false, error: String(lastErr) };
+}
+
+function collectSources() {
+  const sources = [];
+  for (const file of MANIFEST_FILES) {
+    if (!fs.existsSync(file)) {
+      console.log(`Skipping missing manifest: ${file}`);
+      continue;
+    }
+    const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+    const arr = Array.isArray(data) ? data : (data.templates || []);
+    for (const entry of arr) {
+      if (typeof entry?.source === 'string' && /^https?:\/\//i.test(entry.source)) {
+        sources.push({
+          file,
+          id: entry.id,
+          title: entry.title || entry.name || '(no title)',
+          source: entry.source,
+        });
+      }
+    }
+  }
+  return sources;
+}
+
+async function runPool(items, worker, concurrency) {
+  const results = new Array(items.length);
+  let i = 0;
+  const runners = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+    while (i < items.length) {
+      const idx = i++;
+      results[idx] = await worker(items[idx]);
+    }
+  });
+  await Promise.all(runners);
+  return results;
+}
+
+(async () => {
+  const sources = collectSources();
+  console.log(`Probing ${sources.length} source URL(s) across ${MANIFEST_FILES.length} manifest(s)...`);
+
+  const results = await runPool(
+    sources,
+    async (s) => ({ ...s, ...(await probe(s.source)) }),
+    CONCURRENCY,
+  );
+
+  const broken = results.filter((r) => !r.ok);
+
+  const lines = [];
+  lines.push(`# Template Source URL Validation`);
+  lines.push('');
+  lines.push(`Checked **${results.length}** URLs. **${broken.length}** broken.`);
+  if (broken.length) {
+    lines.push('');
+    lines.push('| Manifest | Title | Status | Source |');
+    lines.push('|---|---|---|---|');
+    for (const b of broken) {
+      const status = b.status || b.error || 'unknown';
+      lines.push(`| \`${b.file}\` | ${b.title} | ${status} | ${b.source} |`);
+    }
+  }
+  const report = lines.join('\n') + '\n';
+  fs.writeFileSync('broken-sources.md', report);
+
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, report);
+  }
+
+  if (broken.length) {
+    console.error(`\n${broken.length} broken source URL(s):`);
+    for (const b of broken) {
+      console.error(`  [${b.status || b.error}] ${b.source}`);
+    }
+    if (failOnBroken) process.exit(1);
+  } else {
+    console.log('All source URLs OK.');
+  }
+})().catch((err) => {
+  console.error(err);
+  process.exit(2);
+});

--- a/.github/workflows/validate-template-sources.yml
+++ b/.github/workflows/validate-template-sources.yml
@@ -1,0 +1,81 @@
+name: Validate Template Source URLs
+
+# Verifies that every `source` URL in templates.json and agent-templates.json
+# resolves to a 2xx response. Catches drift caused by upstream repos (e.g.
+# microsoft-foundry/foundry-samples) renaming or removing files we reference.
+#
+# NOTE: GitHub Actions are pinned to full commit SHAs for supply-chain security.
+
+on:
+  pull_request:
+    paths:
+      - "website/static/templates.json"
+      - "website/static/agent-templates.json"
+      - ".github/scripts/validate-template-sources.js"
+      - ".github/workflows/validate-template-sources.yml"
+  schedule:
+    - cron: "0 13 * * 1"  # Mondays 13:00 UTC — weekly drift check
+  workflow_dispatch:
+    inputs:
+      fail_on_broken:
+        description: "Fail the run on any broken source URL (otherwise warn only)"
+        required: true
+        default: true
+        type: boolean
+
+concurrency:
+  group: validate-template-sources-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write           # for scheduled-run failure issues
+  pull-requests: write    # for PR-run summary comments (future use)
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: "24"
+
+      - name: Validate source URLs
+        env:
+          FAIL_ON_BROKEN: ${{ github.event.inputs.fail_on_broken || 'true' }}
+        run: node .github/scripts/validate-template-sources.js
+
+      - name: Open / update tracking issue on scheduled failure
+        if: failure() && github.event_name == 'schedule'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const report = fs.existsSync('broken-sources.md')
+              ? fs.readFileSync('broken-sources.md', 'utf8')
+              : '_No report file produced._';
+            const title = 'Broken template source URLs detected';
+            const { data: existing } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'broken-source-urls',
+              per_page: 1,
+            });
+            const body = `Scheduled run on ${new Date().toISOString().slice(0,10)} detected broken \`source\` URLs in template manifests.\n\n${report}\n\n_Workflow run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}_`;
+            if (existing.length) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: existing[0].number, body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner, repo: context.repo.repo,
+                title, body, labels: ['broken-source-urls'],
+              });
+            }


### PR DESCRIPTION
# Add CI check to validate template `source` URLs

## Why

`templates.json` and `agent-templates.json` contain hardcoded `source` URLs that point into external sample repos (notably `microsoft-foundry/foundry-samples`). Those repos can rename or remove files, breaking the `source` link without any signal here. `azd ai agent init` reads `templates.json` at runtime — when a user picks a template whose `source` 404s, the command fails.

**Concrete recent example:** The "Toolbox (Python, Responses)" entry has pointed at `samples/python/hosted-agents/bring-your-own/responses/toolbox/agent.manifest.yaml` since PR #837 (merged 2026-04-22). Two days later, `foundry-samples` commit [`36a08f6`](https://github.com/microsoft-foundry/foundry-samples/commit/36a08f64e54c6c73e5e8b2697dc38060b55dec4a) renamed `toolbox/` → `bring-your-own-toolbox/`. The link has been a 404 for ~26 days and surfaced only when a customer hit the broken `azd ai agent init` path.

## What this PR adds

A standalone workflow that probes every `source` URL in both manifest files and fails if any are non-2xx.

**Triggers:**
- `pull_request` (path-filtered) — every PR that touches a manifest gets checked, so this class of bug can't be merged in.
- `schedule` (Mondays 13:00 UTC) — catches drift caused by *external* changes (the case above). On scheduled-run failure, opens (or comments on) a tracking issue labelled `broken-source-urls` so the signal doesn't disappear into Actions email.
- `workflow_dispatch` with a `fail_on_broken` toggle for ad-hoc inventory runs.

**What it doesn't do:**
- It doesn't try to fix or suggest replacements. It reports what's broken; humans decide.
- It doesn't validate schema, IDs, or anything other than reachability of `source`. Existing tests cover schema.

## Why a separate workflow (not folded into `discover-templates-extensions.yml`)

Different cadence (weekly vs daily), different trigger surface (PR-gated vs dispatch-only), different failure semantics (fail the build vs create discovery PRs), and would force the existing `discover-templates-extensions` concurrency group to serialize unrelated work. Cleaner as its own file.

## Implementation notes

- Reuses the existing `.github/scripts/url-validation.js` SSRF guard.
- Probes with HEAD; falls back to GET on 403/405 (some CDNs reject HEAD).
- Confirmed empirically that both `github.com/.../blob/...` and `raw.githubusercontent.com/.../...` return clean 404s for missing paths — no URL rewriting needed.
- Concurrency 8, 15s per-request timeout, 2 retries. Total runtime ≈ 10–30s for the current manifest size.
- Output: `broken-sources.md` artifact + `$GITHUB_STEP_SUMMARY` table.
- SHA-pinned actions consistent with the rest of the repo.

## Files

- `.github/workflows/validate-template-sources.yml` (new)
- `.github/scripts/validate-template-sources.js` (new)

## Out of scope (intentional)

This PR adds the check but does **not** fix the existing broken entries (one dead `responses/toolbox` link + two unregistered `langgraph-toolbox*` siblings added by `foundry-samples` commit `36a08f6`). Those will land as a separate, smaller PR so the CI plumbing and the data fix can be reviewed independently. With this workflow merged first, the data-fix PR will be self-verifying.

## Verification

Before merge: run `gh workflow run validate-template-sources.yml -f fail_on_broken=false` on this branch to inventory current state. Expect 1+ broken URLs (the known `responses/toolbox` entry). After the data-fix PR lands, a re-run should be all-green.
