### PR TITLE
fix(pipeline): include azure-sdk in TokenOwners for daily-release

### DIFF
--- a/eng/pipelines/daily-release.yml
+++ b/eng/pipelines/daily-release.yml
@@ -23,7 +23,7 @@ jobs:
       - template: /eng/common/pipelines/templates/steps/login-to-github.yml
         parameters:
           TokenOwners:
-            - azure
+            - azure-sdk
 
       - script: |
           set -e


### PR DESCRIPTION
## Summary

Fixes the 403 in the daily-release pipeline reported after #890:

```
remote: Permission to azure-sdk/awesome-azd.git denied to azure-sdk-automation[bot].
fatal: unable to access 'https://github.com/azure-sdk/awesome-azd.git/': The requested URL returned error: 403
```

## Root cause

#890 replaced `$(azuresdk-github-pat)` with a GitHub App installation token obtained via `login-to-github.yml` using `TokenOwners: [azure]`. That scopes the issued token to the **`Azure`** org only.

The same job then pushes built site assets to:

```
https://github.com/azure-sdk/awesome-azd.git   (gh-pages)
```

…which lives in the **`azure-sdk`** org — a different org. The App token has no permission there, so GitHub returns 403.

## Fix

Add `azure-sdk` to `TokenOwners` so the issued installation token covers the push target.

```yaml
- template: /eng/common/pipelines/templates/steps/login-to-github.yml
  parameters:
    TokenOwners:
      - azure
      - azure-sdk
```

## Prerequisite to verify

This fix assumes the `azure-sdk-automation` GitHub App is installed on `azure-sdk/awesome-azd` with `contents: write`. If it isn''t, the 403 will persist and the eng-sys / SDK release team will need to install/grant it there.

## Test

The `awesome-azd - daily` pipeline (definitionId 6575) will exercise this on its next run; can also be kicked manually to confirm.