### PR TITLE
fix: comment out extension contribution link until we are ready for community contributions

### DIFF
--- a/website/src/components/gallery/ShowcaseTemplateSearch/index.tsx
+++ b/website/src/components/gallery/ShowcaseTemplateSearch/index.tsx
@@ -254,7 +254,7 @@ export default function ShowcaseTemplateSearch() {
                       Learn more in our docs.
                     </FluentUILink>
                   </Text>
-                  <Text
+                  {/* <Text
                     size={300}
                     className={styles.heroSubtext}
                     block
@@ -268,7 +268,7 @@ export default function ShowcaseTemplateSearch() {
                     >
                       Submit it here
                     </FluentUILink>
-                  </Text>
+                  </Text> */}
                 </>
               : <a
                     href={gettingStartedUrl}


### PR DESCRIPTION
## Summary

Comments out the `Built an extension? Submit it here` `<Text>` block in the extensions tab hero section of the gallery (`website/src/components/gallery/ShowcaseTemplateSearch/index.tsx`).

The block is preserved as a JSX comment so it can be easily re-enabled later.

## Changes

- Wrapped the second `<Text>` element (containing the `Submit it here` link to the extension submission issue template) in `{/* ... */}` JSX comment markers.

No other behavior is affected.

Related to https://github.com/Azure/awesome-azd/issues/895. When working on it, we will comment this part back. 