### PR TITLE
Add Functions Java and PowerShell timer templates (follow-on to #914)

### DIFF
--- a/website/static/templates.json
+++ b/website/static/templates.json
@@ -9411,5 +9411,55 @@
       "bicep"
     ],
     "id": "1e89afe2-59d7-481f-ae63-749888d6de48"
+  },
+  {
+    "title": "Azure Functions Java Timer Trigger using Azure Developer CLI",
+    "description": "This repository contains an Azure Functions Timer trigger quickstart written in Java and deployed to Azure Functions Flex Consumption using the Azure Developer CLI (AZD). This sample uses managed identity and a virtual network to ensure it's secure by default.",
+    "preview": "./templates/images/test.png",
+    "authorUrl": "https://github.com/Azure-Samples",
+    "author": "Azure Functions Team",
+    "source": "https://github.com/Azure-Samples/functions-quickstart-java-azd-timer",
+    "tags": [
+      "msft",
+      "new"
+    ],
+    "languages": [
+      "java"
+    ],
+    "azureServices": [
+      "functions",
+      "managedidentity",
+      "vnets",
+      "appinsights"
+    ],
+    "IaC": [
+      "bicep"
+    ],
+    "id": "b2f795d2-9e27-4232-be88-e2ef71518dae"
+  },
+  {
+    "title": "Azure Functions PowerShell Timer Trigger using Azure Developer CLI",
+    "description": "This repository contains an Azure Functions Timer trigger quickstart written in PowerShell and deployed to Azure Functions Flex Consumption using the Azure Developer CLI (AZD). This sample uses managed identity and a virtual network to ensure it's secure by default.",
+    "preview": "./templates/images/test.png",
+    "authorUrl": "https://github.com/Azure-Samples",
+    "author": "Azure Functions Team",
+    "source": "https://github.com/Azure-Samples/functions-quickstart-powershell-azd-timer",
+    "tags": [
+      "msft",
+      "new"
+    ],
+    "languages": [
+      "powershell"
+    ],
+    "azureServices": [
+      "functions",
+      "managedidentity",
+      "vnets",
+      "appinsights"
+    ],
+    "IaC": [
+      "bicep"
+    ],
+    "id": "8b91b751-45bf-4e9a-9a51-f072018ecee2"
   }
 ]

--- a/website/static/templates.json
+++ b/website/static/templates.json
@@ -9446,10 +9446,8 @@
     "source": "https://github.com/Azure-Samples/functions-quickstart-powershell-azd-timer",
     "tags": [
       "msft",
+      "powershell",
       "new"
-    ],
-    "languages": [
-      "powershell"
     ],
     "azureServices": [
       "functions",


### PR DESCRIPTION
Adds two Azure Functions Timer trigger quickstart templates to the gallery, completing the Functions timer language set:

- `functions-quickstart-java-azd-timer`
- `functions-quickstart-powershell-azd-timer`

### Context

Follow-on to **#914**, which added the Python / JavaScript / TypeScript timer quickstarts. Java and PowerShell each needed upstream fixes in their sample repos; those fixes are **now all merged**:

| Language | Sample repo | Upstream fix |
| --- | --- | --- |
| Python | [functions-quickstart-python-azd-timer](https://github.com/Azure-Samples/functions-quickstart-python-azd-timer) | merged ✅ |
| JavaScript | [functions-quickstart-javascript-azd-timer](https://github.com/Azure-Samples/functions-quickstart-javascript-azd-timer) | merged ✅ |
| TypeScript | [functions-quickstart-typescript-azd-timer](https://github.com/Azure-Samples/functions-quickstart-typescript-azd-timer) | n/a (already passing) |
| Java | [functions-quickstart-java-azd-timer](https://github.com/Azure-Samples/functions-quickstart-java-azd-timer) | [PR #3](https://github.com/Azure-Samples/functions-quickstart-java-azd-timer/pull/3) merged ✅ |
| PowerShell | [functions-quickstart-powershell-azd-timer](https://github.com/Azure-Samples/functions-quickstart-powershell-azd-timer) | [PR #5](https://github.com/Azure-Samples/functions-quickstart-powershell-azd-timer/pull/5) merged ✅ |

### Changes

- `website/static/templates.json`: two new `msft` entries with the same shape and tagging as the [existing .NET timer entry](https://github.com/Azure/awesome-azd/blob/main/website/static/templates.json) and the three entries in #914.

### Validation

- `npm test` — all 373 tests pass.
- Tags re-used (`java`, `powershell`, `functions`, `managedidentity`, `vnets`, `appinsights`, `bicep`) all already exist in `website/src/data/tags.tsx`.
- End-to-end `azd up` deployment proof for both samples posted in the review threads — function apps deploy and timers fire on schedule.

Closes out the original ask in #844.