### PR TITLE
Add functions-quickstart-dotnet-azd-tf to awesome-azd gallery

### DIFF
--- a/website/static/templates.json
+++ b/website/static/templates.json
@@ -9427,5 +9427,28 @@
       "bicep"
     ],
     "id": "8b91b751-45bf-4e9a-9a51-f072018ecee2"
+  },
+  {
+    "title": "Azure Functions C# HTTP Trigger using Azure Developer CLI (Terraform)",
+    "description": "This repository contains an Azure Functions HTTP trigger quickstart written in C# (isolated process mode) and deployed to Azure Functions Flex Consumption using the Azure Developer CLI (azd) with Terraform as the IaC provider. The sample uses managed identity and a virtual network to make sure deployment is secure by default.",
+    "preview": "./templates/images/functions-quickstart-dotnet-azd-tf.png",
+    "authorUrl": "https://github.com/Azure-Samples",
+    "author": "Azure Functions Team",
+    "source": "https://github.com/Azure-Samples/functions-quickstart-dotnet-azd-tf",
+    "tags": [
+      "msft",
+      "terraform",
+      "new"
+    ],
+    "azureServices": [
+      "functions",
+      "managedidentity",
+      "vnets",
+      "appinsights"
+    ],
+    "id": "cff3f8db-2d8c-425e-b377-67f434df2187",
+    "languages": [
+      "dotnetCsharp"
+    ]
   }
 ]

--- a/website/static/templates.json
+++ b/website/static/templates.json
@@ -9431,7 +9431,7 @@
   {
     "title": "Azure Functions C# HTTP Trigger using Azure Developer CLI (Terraform)",
     "description": "This repository contains an Azure Functions HTTP trigger quickstart written in C# (isolated process mode) and deployed to Azure Functions Flex Consumption using the Azure Developer CLI (azd) with Terraform as the IaC provider. The sample uses managed identity and a virtual network to make sure deployment is secure by default.",
-    "preview": "./templates/images/functions-quickstart-dotnet-azd-tf.png",
+    "preview": "./templates/images/test.png",
     "authorUrl": "https://github.com/Azure-Samples",
     "author": "Azure Functions Team",
     "source": "https://github.com/Azure-Samples/functions-quickstart-dotnet-azd-tf",


### PR DESCRIPTION
## Purpose

Adds the **Terraform** IaC variant of the Azure Functions C# HTTP trigger quickstart to the awesome-azd gallery.

The Bicep-based sibling, [`functions-quickstart-dotnet-azd`](https://github.com/Azure-Samples/functions-quickstart-dotnet-azd), is already in the gallery. This PR brings in the **Terraform** variant ([`functions-quickstart-dotnet-azd-tf`](https://github.com/Azure-Samples/functions-quickstart-dotnet-azd-tf)) so users get the full set of IaC options for the C# HTTP trigger quickstart.

Closes #917.

## What's in this PR

1. Appends one entry to `website/static/templates.json` pointing at https://github.com/Azure-Samples/functions-quickstart-dotnet-azd-tf
2. Preview image at `website/static/templates/images/functions-quickstart-dotnet-azd-tf.png` — **end-to-end deployment screenshots to be attached/committed by the author.**

## What to Check

- New entry id is unique (`cff3f8db-2d8c-425e-b377-67f434df2187`)
- Source repo URL works
- Tags include `terraform` (IaC provider), matching the convention used by existing Terraform entries
- `languages` (`dotnetCsharp`) and `azureServices` (`functions`, `managedidentity`, `vnets`, `appinsights`) match the sibling Functions quickstart entries

## Other Information

The template (code + Terraform IaC) has been tested end to end on Azure. Follows the same contribution pattern as #808 and #877.
