### PR TITLE
Update Foundry hosted-agent templates to reference azure.yaml

### DIFF
--- a/website/static/templates.json
+++ b/website/static/templates.json
@@ -7226,11 +7226,11 @@
     "description": "Minimal Hello World agent using the Responses protocol with the Agent Framework approach in C#. Uses Microsoft.Agents.AI to create an AIAgent backed by a Foundry model.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
-    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/csharp/hosted-agents/agent-framework/hello-world/agent.manifest.yaml",
+    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/csharp/hosted-agents/agent-framework/hello-world/azure.yaml",
     "languages": [
       "dotnetCsharp"
     ],
-    "id": "9db1dc5d-772e-50cd-8e29-2a70bef8c872",
+    "id": "5f0850f8-f6ef-576b-a8ae-c5b6d78eb78f",
     "templateType": "extension.ai.agent",
     "extensionFramework": "Agent Framework",
     "extensionTags": [
@@ -7245,11 +7245,11 @@
     "description": "A minimal echo agent hosted as a Foundry Hosted Agent using the Invocations protocol and the Agent Framework. No LLM or Azure credentials required.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
-    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/csharp/hosted-agents/agent-framework/invocations-echo-agent/agent.manifest.yaml",
+    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/csharp/hosted-agents/agent-framework/invocations-echo-agent/azure.yaml",
     "languages": [
       "dotnetCsharp"
     ],
-    "id": "c948c0bd-8b9e-56f3-b4fb-86ef1d4096fd",
+    "id": "7aa2bad6-bc53-5e57-9610-ccf0aa8cf0fb",
     "templateType": "extension.ai.agent",
     "extensionFramework": "Agent Framework",
     "extensionTags": [
@@ -7262,11 +7262,11 @@
     "description": "A travel assistant agent with local C# function tools for hotel search in Seattle.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
-    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/csharp/hosted-agents/agent-framework/local-tools/agent.manifest.yaml",
+    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/csharp/hosted-agents/agent-framework/local-tools/azure.yaml",
     "languages": [
       "dotnetCsharp"
     ],
-    "id": "06917df3-c1b5-5f96-a2ed-206883a31c84",
+    "id": "455b66ab-1c3d-53fa-89f3-5e4555a1cc70",
     "templateType": "extension.ai.agent",
     "extensionFramework": "Agent Framework",
     "extensionTags": [
@@ -7280,11 +7280,11 @@
     "description": "A developer assistant with remote MCP tools connecting to GitHub and Microsoft Learn documentation servers.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
-    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/csharp/hosted-agents/agent-framework/mcp-tools/agent.manifest.yaml",
+    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/csharp/hosted-agents/agent-framework/mcp-tools/azure.yaml",
     "languages": [
       "dotnetCsharp"
     ],
-    "id": "a634f96e-a6fa-5305-a6e6-8e243f86039c",
+    "id": "49dd2e87-7d2e-59b5-bcf2-7015b621da84",
     "templateType": "extension.ai.agent",
     "extensionFramework": "Agent Framework",
     "extensionTags": [
@@ -7298,11 +7298,11 @@
     "description": "A simple general-purpose AI assistant hosted as a Foundry Hosted Agent using the Agent Framework.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
-    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/csharp/hosted-agents/agent-framework/simple-agent/agent.manifest.yaml",
+    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/csharp/hosted-agents/agent-framework/simple-agent/azure.yaml",
     "languages": [
       "dotnetCsharp"
     ],
-    "id": "d27ec121-fc2e-5607-8e40-998cb0268c35",
+    "id": "2e947be9-4044-5f88-91b0-ce298825f454",
     "templateType": "extension.ai.agent",
     "extensionFramework": "Agent Framework",
     "extensionTags": [
@@ -7315,11 +7315,11 @@
     "description": "A support specialist agent with RAG capabilities using TextSearchProvider to ground answers in product documentation.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
-    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/csharp/hosted-agents/agent-framework/text-search-rag/agent.manifest.yaml",
+    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/csharp/hosted-agents/agent-framework/text-search-rag/azure.yaml",
     "languages": [
       "dotnetCsharp"
     ],
-    "id": "89bd6444-b880-5e9c-a6e9-dd22effd4eb2",
+    "id": "aabeaf2b-7e2e-5274-99ac-acea701ec34d",
     "templateType": "extension.ai.agent",
     "extensionFramework": "Agent Framework",
     "extensionTags": [
@@ -7333,11 +7333,11 @@
     "description": "A workflow agent that performs sequential translation through multiple languages (English to French to Spanish to English).",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
-    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/csharp/hosted-agents/agent-framework/workflows/agent.manifest.yaml",
+    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/csharp/hosted-agents/agent-framework/workflows/azure.yaml",
     "languages": [
       "dotnetCsharp"
     ],
-    "id": "575f8351-192b-5c74-8803-b816090e806a",
+    "id": "ebab1899-6f93-5a12-93db-9b3d688c1a8e",
     "templateType": "extension.ai.agent",
     "extensionFramework": "Agent Framework",
     "extensionTags": [
@@ -7351,11 +7351,11 @@
     "description": "Minimal Hello World agent using the Invocations protocol with a bring-your-own approach in C#. Calls a Foundry model via the Responses API and returns the response as a streaming SSE event stream.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
-    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/csharp/hosted-agents/bring-your-own/invocations/HelloWorld/agent.manifest.yaml",
+    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/csharp/hosted-agents/bring-your-own/invocations/HelloWorld/azure.yaml",
     "languages": [
       "dotnetCsharp"
     ],
-    "id": "1dc4e8fd-8a01-537a-b52a-d67211171a18",
+    "id": "a35cd56b-cad5-506e-beec-718f6fa80d87",
     "templateType": "extension.ai.agent",
     "extensionFramework": "Bring Your Own",
     "extensionTags": [
@@ -7369,11 +7369,11 @@
     "description": "A human-in-the-loop agent that demonstrates the approval-gate pattern using the Azure.AI.AgentServer.Invocations SDK with Azure OpenAI.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
-    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/csharp/hosted-agents/bring-your-own/invocations/human-in-the-loop/agent.manifest.yaml",
+    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/csharp/hosted-agents/bring-your-own/invocations/human-in-the-loop/azure.yaml",
     "languages": [
       "dotnetCsharp"
     ],
-    "id": "eb392fb4-dedb-536f-8bca-b0b556985769",
+    "id": "4f46ddca-048c-56c3-9e56-f21498e7ca37",
     "templateType": "extension.ai.agent",
     "extensionFramework": "Bring Your Own",
     "extensionTags": [
@@ -7387,11 +7387,11 @@
     "description": "A note-taking agent using the Invocations protocol with Azure OpenAI function calling in C#. Demonstrates tool use with per-session JSONL persistence and SSE streaming.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
-    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/csharp/hosted-agents/bring-your-own/invocations/notetaking-agent/agent.manifest.yaml",
+    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/csharp/hosted-agents/bring-your-own/invocations/notetaking-agent/azure.yaml",
     "languages": [
       "dotnetCsharp"
     ],
-    "id": "0546df51-07d7-55bd-9b01-5ba0443640f6",
+    "id": "4ca8e775-1741-5793-9806-4f3fd3ce73d9",
     "templateType": "extension.ai.agent",
     "extensionFramework": "Bring Your Own",
     "extensionTags": [
@@ -7404,11 +7404,11 @@
     "description": "Minimal Hello World agent using the Responses protocol with a bring-your-own approach in C#. Calls a Foundry model via the Responses API and returns the response.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
-    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/csharp/hosted-agents/bring-your-own/responses/HelloWorld/agent.manifest.yaml",
+    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/csharp/hosted-agents/bring-your-own/responses/HelloWorld/azure.yaml",
     "languages": [
       "dotnetCsharp"
     ],
-    "id": "0b764050-5812-56df-a206-202e6bc725a1",
+    "id": "80b9c6eb-63ba-53a9-84eb-ac7292519e2b",
     "templateType": "extension.ai.agent",
     "extensionFramework": "Bring Your Own",
     "extensionTags": [
@@ -7421,11 +7421,11 @@
     "description": "A long-running research agent that demonstrates the background execution pattern using the Azure.AI.AgentServer.Responses SDK with Azure OpenAI.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
-    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/csharp/hosted-agents/bring-your-own/responses/background-agent/agent.manifest.yaml",
+    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/csharp/hosted-agents/bring-your-own/responses/background-agent/azure.yaml",
     "languages": [
       "dotnetCsharp"
     ],
-    "id": "acc8f372-c6be-5959-950e-3473443ac55d",
+    "id": "ddecab76-394e-5aac-a9c7-ce2d15f1e482",
     "templateType": "extension.ai.agent",
     "extensionFramework": "Bring Your Own",
     "extensionTags": [
@@ -7438,11 +7438,11 @@
     "description": "A note-taking agent using the Responses protocol with Azure OpenAI function calling in C#. Demonstrates tool use with per-session JSONL persistence.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
-    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/csharp/hosted-agents/bring-your-own/responses/notetaking-agent/agent.manifest.yaml",
+    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/csharp/hosted-agents/bring-your-own/responses/notetaking-agent/azure.yaml",
     "languages": [
       "dotnetCsharp"
     ],
-    "id": "025b0c06-1709-5298-8b96-3e98eb4fc34b",
+    "id": "29b65cdf-5a18-5369-95fe-81a1692b2efb",
     "templateType": "extension.ai.agent",
     "extensionFramework": "Bring Your Own",
     "extensionTags": [
@@ -7456,11 +7456,11 @@
     "description": "A basic Agent Framework agent hosted by Foundry using the Invocations protocol.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
-    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/agent-framework/invocations/01-basic/agent.manifest.yaml",
+    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/agent-framework/invocations/01-basic/azure.yaml",
     "languages": [
       "python"
     ],
-    "id": "1b161baf-a3f7-5327-b68c-0f68c22adcab",
+    "id": "ccb2c95a-9d89-51ce-b078-48a04c61cbb4",
     "templateType": "extension.ai.agent",
     "extensionFramework": "Agent Framework",
     "extensionTags": [
@@ -7474,11 +7474,11 @@
     "description": "A basic Agent Framework agent hosted by Foundry using the Responses protocol.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
-    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/agent-framework/responses/01-basic/agent.manifest.yaml",
+    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/agent-framework/responses/01-basic/azure.yaml",
     "languages": [
       "python"
     ],
-    "id": "8436aaad-67c3-57ae-8864-71ca0705214b",
+    "id": "ecf556ea-2c78-575f-afe1-84ab7ebfe147",
     "templateType": "extension.ai.agent",
     "extensionFramework": "Agent Framework",
     "extensionTags": [
@@ -7493,11 +7493,11 @@
     "description": "An Agent Framework agent with local tools hosted by Foundry.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
-    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/agent-framework/responses/02-tools/agent.manifest.yaml",
+    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/agent-framework/responses/02-tools/azure.yaml",
     "languages": [
       "python"
     ],
-    "id": "4d6e5316-2914-5387-9b96-ec7bbb0fa58b",
+    "id": "b8c79360-034d-5fb8-ae7d-1417b72d0163",
     "templateType": "extension.ai.agent",
     "extensionFramework": "Agent Framework",
     "extensionTags": [
@@ -7511,11 +7511,11 @@
     "description": "An Agent Framework agent with remote MCP tools hosted by Foundry.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
-    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/agent-framework/responses/03-mcp/agent.manifest.yaml",
+    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/agent-framework/responses/03-mcp/azure.yaml",
     "languages": [
       "python"
     ],
-    "id": "d708512c-2cf7-5515-be29-a2569f684f5f",
+    "id": "2e60319a-a2b8-5e44-a328-4dee879a974b",
     "templateType": "extension.ai.agent",
     "extensionFramework": "Agent Framework",
     "extensionTags": [
@@ -7529,11 +7529,11 @@
     "description": "An Agent Framework agent with Foundry Toolbox integration.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
-    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/agent-framework/responses/04-foundry-toolbox/agent.manifest.yaml",
+    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/agent-framework/responses/04-foundry-toolbox/azure.yaml",
     "languages": [
       "python"
     ],
-    "id": "b6fde495-8f29-5dd5-b36a-a9ed68910eae",
+    "id": "7bc55faa-e690-5098-8ff7-ce98034263de",
     "templateType": "extension.ai.agent",
     "extensionFramework": "Agent Framework",
     "extensionTags": [
@@ -7547,11 +7547,11 @@
     "description": "An Agent Framework workflow hosted by Foundry.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
-    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/agent-framework/responses/05-workflows/agent.manifest.yaml",
+    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/agent-framework/responses/05-workflows/azure.yaml",
     "languages": [
       "python"
     ],
-    "id": "0b59af9c-5080-5bdb-8d42-acc7b261f355",
+    "id": "448329aa-7d14-59ef-887e-d6c2fd2e33f5",
     "templateType": "extension.ai.agent",
     "extensionFramework": "Agent Framework",
     "extensionTags": [
@@ -7564,11 +7564,11 @@
     "description": "AG-UI protocol over Foundry invocations using Pydantic AI with Azure OpenAI. Streams standard AG-UI events with zero manual event translation.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
-    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/bring-your-own/invocations/ag-ui/agent.manifest.yaml",
+    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/bring-your-own/invocations/ag-ui/azure.yaml",
     "languages": [
       "python"
     ],
-    "id": "177b6f18-27b8-51ea-81c0-a6baf184e15d",
+    "id": "9eb2c7ee-fe7f-5cbb-b26e-26f7e7d98c73",
     "templateType": "extension.ai.agent",
     "extensionFramework": "Bring Your Own",
     "extensionTags": [
@@ -7582,11 +7582,11 @@
     "description": "A getting-started agent that uses the GitHub Copilot SDK with the azure-ai-agentserver-invocations protocol, streaming raw session events as SSE.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
-    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/bring-your-own/invocations/github-copilot/agent.manifest.yaml",
+    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/bring-your-own/invocations/github-copilot/azure.yaml",
     "languages": [
       "python"
     ],
-    "id": "743d84fc-98b4-5cf0-b542-38d534239fb6",
+    "id": "09d191c5-54fd-5cd6-a950-f22d81fbae1f",
     "templateType": "extension.ai.agent",
     "extensionFramework": "Bring Your Own",
     "extensionTags": [
@@ -7599,11 +7599,11 @@
     "description": "Minimal Hello World agent using the Invocations protocol with a bring-your-own approach. Calls a Foundry model via the Responses API and returns the response as a streaming SSE event stream.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
-    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/bring-your-own/invocations/hello-world/agent.manifest.yaml",
+    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/bring-your-own/invocations/hello-world/azure.yaml",
     "languages": [
       "python"
     ],
-    "id": "f2460948-3484-5840-bc8c-6d392c99e3c4",
+    "id": "f0b264f9-d3eb-5c43-aa5d-eaae7d400eac",
     "templateType": "extension.ai.agent",
     "extensionFramework": "Bring Your Own",
     "extensionTags": [
@@ -7616,11 +7616,11 @@
     "description": "A human-in-the-loop agent that demonstrates the approval-gate pattern using the azure-ai-agentserver-invocations SDK.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
-    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/bring-your-own/invocations/human-in-the-loop/agent.manifest.yaml",
+    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/bring-your-own/invocations/human-in-the-loop/azure.yaml",
     "languages": [
       "python"
     ],
-    "id": "ba3e0cf8-bcdf-5747-9019-740723a72752",
+    "id": "71a5ba2b-e2e6-5a37-bff6-7d60e2c15a5e",
     "templateType": "extension.ai.agent",
     "extensionFramework": "Bring Your Own",
     "extensionTags": [
@@ -7634,11 +7634,11 @@
     "description": "Multi-turn chat agent built with LangGraph and the Invocations protocol. Demonstrates a tool-calling agent graph with get_current_time and calculator tools.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
-    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/bring-your-own/invocations/langgraph-chat/agent.manifest.yaml",
+    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/bring-your-own/invocations/langgraph-chat/azure.yaml",
     "languages": [
       "python"
     ],
-    "id": "938dfe3d-bbd8-56ef-9698-c60cb1274c90",
+    "id": "1e80fcee-9fac-507a-a8e4-6a9d042e0762",
     "templateType": "extension.ai.agent",
     "extensionFramework": "LangGraph",
     "extensionTags": [
@@ -7652,11 +7652,11 @@
     "description": "Note-taking agent using the Invocations protocol. Demonstrates function calling (save_note/get_notes tools) with per-session JSONL persistence and SSE streaming.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
-    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/bring-your-own/invocations/notetaking-agent/agent.manifest.yaml",
+    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/bring-your-own/invocations/notetaking-agent/azure.yaml",
     "languages": [
       "python"
     ],
-    "id": "de52823b-f7de-543f-9003-07741562e819",
+    "id": "d473dc6c-d439-502a-8821-8659b063ec90",
     "templateType": "extension.ai.agent",
     "extensionFramework": "Bring Your Own",
     "extensionTags": [
@@ -7669,11 +7669,11 @@
     "description": "Bring-your-own agent using the Invocations protocol with Foundry Toolbox MCP integration. Connects to a toolbox at startup, discovers tools, and lets the model call them during conversation.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
-    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/bring-your-own/invocations/toolbox/agent.manifest.yaml",
+    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/bring-your-own/invocations/toolbox/azure.yaml",
     "languages": [
       "python"
     ],
-    "id": "65cc0e89-15a5-593c-8e7e-ddb7997c5ce3",
+    "id": "79b115d8-360a-5ef1-8d2e-35d98ea151b8",
     "templateType": "extension.ai.agent",
     "extensionFramework": "Bring Your Own",
     "extensionTags": [
@@ -7686,11 +7686,11 @@
     "description": "A long-running agent that demonstrates the background execution pattern using the azure-ai-agentserver-responses SDK. Supports polling and cancellation.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
-    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/bring-your-own/responses/background-agent/agent.manifest.yaml",
+    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/bring-your-own/responses/background-agent/azure.yaml",
     "languages": [
       "python"
     ],
-    "id": "daf8e726-611f-51e4-9a2b-6b849143d5ac",
+    "id": "63fc9f3f-b286-592b-9e8d-be86d7594d28",
     "templateType": "extension.ai.agent",
     "extensionFramework": "Bring Your Own",
     "extensionTags": [
@@ -7703,11 +7703,11 @@
     "description": "Minimal Hello World agent using the Responses protocol with a bring-your-own approach. Calls a Foundry model via the Responses API and returns the response.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
-    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/bring-your-own/responses/hello-world/agent.manifest.yaml",
+    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/bring-your-own/responses/hello-world/azure.yaml",
     "languages": [
       "python"
     ],
-    "id": "009ce7d3-656e-50bd-9963-9986d3b15263",
+    "id": "8db2305f-f78d-5ba8-b013-e12cd3a7ca89",
     "templateType": "extension.ai.agent",
     "extensionFramework": "Bring Your Own",
     "extensionTags": [
@@ -7720,11 +7720,11 @@
     "description": "Multi-turn chat agent built with LangGraph using the Responses protocol. Demonstrates a tool-calling agent graph with server-side conversation state.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
-    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/bring-your-own/responses/langgraph-chat/agent.manifest.yaml",
+    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/bring-your-own/responses/langgraph-chat/azure.yaml",
     "languages": [
       "python"
     ],
-    "id": "9cc2f69d-137c-5bca-90f2-ada236513caf",
+    "id": "eb51c66f-854a-54f2-b26b-0bb10e9c1548",
     "templateType": "extension.ai.agent",
     "extensionFramework": "LangGraph",
     "extensionTags": [
@@ -7738,11 +7738,11 @@
     "description": "Note-taking agent using the Responses protocol. Demonstrates function calling (save_note/get_notes tools) with per-session JSONL persistence and streaming responses.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
-    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/bring-your-own/responses/notetaking-agent/agent.manifest.yaml",
+    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/bring-your-own/responses/notetaking-agent/azure.yaml",
     "languages": [
       "python"
     ],
-    "id": "881c2f3d-c182-589a-b456-b08411cbd807",
+    "id": "de8603d7-60fd-53f4-b67d-1dbcffadbbf1",
     "templateType": "extension.ai.agent",
     "extensionFramework": "Bring Your Own",
     "extensionTags": [
@@ -7756,11 +7756,11 @@
     "description": "Bring-your-own agent using the Responses protocol with Foundry Toolbox MCP integration. Connects to a toolbox at startup, discovers tools, and lets the model call them during conversation.",
     "authorUrl": "https://github.com/microsoft-foundry",
     "author": "Microsoft Foundry Team",
-    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/bring-your-own/responses/bring-your-own-toolbox/agent.manifest.yaml",
+    "source": "https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/bring-your-own/responses/bring-your-own-toolbox/azure.yaml",
     "languages": [
       "python"
     ],
-    "id": "6c5e110d-fd0f-5c81-8f7d-9b188257e115",
+    "id": "0b72368d-0fe7-500e-8f5d-cf8345e00c50",
     "templateType": "extension.ai.agent",
     "extensionFramework": "Bring Your Own",
     "extensionTags": [


### PR DESCRIPTION
## What this does

Updates the Foundry hosted-agent entries in `website/static/templates.json` to follow the upstream sample migration in microsoft-foundry/foundry-samples-pr#601, which moves every hosted-agent sample from the legacy two-file shape (`agent.yaml` + `agent.manifest.yaml`) to a single inline `azure.yaml` (with agent source relocated under `src/<agent-name>/`).

## Changes

All 31 `templateType: "extension.ai.agent"` entries are updated:

- **Source URL**: the trailing `agent.manifest.yaml` is swapped for `azure.yaml`. The host, repo (`microsoft-foundry/foundry-samples`), branch (`main`), and sample directory path are unchanged. Verified against the PR file list that a matching `azure.yaml` exists at the exact same path for every one of the 31 samples (31/31, 0 missing).
- **ID**: each `id` is regenerated. Agent template ids are a deterministic UUID v5 of `awesome-azd:agent:<source>` (enforced by `website/test/agent-templates.test.ts`), so changing the source requires recomputing the id. Ids were regenerated with the exact algorithm the test uses.

Net diff: 31 source lines + 31 id lines (62 insertions, 62 deletions); no other entries touched.

## Validation

`cd website && npm test` -> 351 passed, 351 total. `test/agent-templates.test.ts` (including the deterministic-id invariant) passes. The only failing suite is `test/consent-banner.test.ts`, which fails identically on a clean `main` due to a pre-existing missing dev dependency (`jest-environment-jsdom` not installed) and is unrelated to this change.

## Draft / merge timing

Opened as a draft on purpose. PR #601 currently lives in the `foundry-samples-pr` repo; the public `microsoft-foundry/foundry-samples` repo still serves the legacy `agent.manifest.yaml` and does not yet have `azure.yaml`. Until that migration is published to the public repo, these `source` links will 404. This should be marked ready / merged in lockstep with the public `foundry-samples` publish.
