### PR TITLE
fix(website): gate dual-purpose analytics cookies behind WCP consent

### DIFF
--- a/website/src/theme/Root.js
+++ b/website/src/theme/Root.js
@@ -14,6 +14,9 @@ const telemetryInit = () => {
   const SET = "set";
   const RESET = "reset";
   var siteConsent = null;
+  // Guard so Clarity initializes at most once even if the consent callback
+  // fires repeatedly (e.g. via the "Manage Cookies" dialog).
+  var clarityInitialized = false;
 
   function onConsentChanged(categoryPreferences) {
     setNonEssentialCookies(categoryPreferences);
@@ -41,11 +44,21 @@ const telemetryInit = () => {
 
   function setClarity(setString) {
     if (setString === SET) {
-      Clarity.init("r8ugpuymsy");
+      if (!clarityInitialized) {
+        Clarity.init("r8ugpuymsy");
+        clarityInitialized = true;
+      }
       Clarity.consent(true);
     } else {
-      Cookies.remove("_clck", { domain: ".microsoft.com" });
-      Cookies.remove("_clsk", { domain: ".microsoft.com" });
+      if (clarityInitialized) {
+        Clarity.consent(false);
+      }
+      // Clarity sets _clck/_clsk on the current host (e.g. azure.github.io), so
+      // remove without a domain as well as with .microsoft.com for safety.
+      ["_clck", "_clsk"].forEach(function (cookieName) {
+        Cookies.remove(cookieName);
+        Cookies.remove(cookieName, { domain: ".microsoft.com" });
+      });
     }
   }
 
@@ -54,6 +67,12 @@ const telemetryInit = () => {
       setClarity(SET);
     } else {
       setClarity(RESET);
+      // Analytics not consented: 1DS keeps running so its essential Required
+      // telemetry (MicrosoftApplicationsTelemetry* device cookies) continues,
+      // but best-effort remove the non-essential dual-purpose MSFPC identity
+      // cookie so it never persists without consent.
+      Cookies.remove("MSFPC");
+      Cookies.remove("MSFPC", { domain: ".microsoft.com" });
     }
   }
 
@@ -171,9 +190,18 @@ const telemetryInit = () => {
       propertyConfiguration: {
         callback: {
           userConsentDetails: function () {
-            return siteConsent && siteConsent.getConsent
-              ? siteConsent.getConsent()
-              : null;
+            // Live consent lookup. Until WCP resolves, report non-essential
+            // categories as denied so 1DS collects only Required telemetry and
+            // writes no analytics cookies (e.g. MSFPC) before the user consents.
+            if (siteConsent && siteConsent.getConsent) {
+              return siteConsent.getConsent();
+            }
+            return {
+              Required: true,
+              Analytics: false,
+              SocialMedia: false,
+              Advertising: false,
+            };
           },
         },
       },


### PR DESCRIPTION
Fix https://github.com/Azure/ai-app-templates/issues/796

## Summary

Ensure the awesome-azd site writes **no non-essential / dual-purpose cookies before WCP Analytics consent**, while still collecting **Required (essential) 1DS telemetry**. Mirrors the fix merged for the AI App Templates gallery.

The dual-purpose cookies flagged by web-compliance scans come from **Microsoft Clarity** and the Bing cookies it loads (`MUID`, `ANONCHK`, `MR`, `SM`, `SRM_B`); those are gated behind Analytics consent. Microsoft 1DS / OneDS telemetry (JSLL 4.2.3) keeps running so Required telemetry is not lost — only its non-essential first-party identity cookie (`MSFPC`) is gated on consent.

## Changes (`website/src/theme/Root.js`)

- **Gate Microsoft Clarity fully behind Analytics consent**: init-once guard, `Clarity.consent(false)` on revoke, and clear `_clck` / `_clsk` both host-scoped and on `.microsoft.com` — the site is served from `azure.github.io`, so the previous `.microsoft.com`-only removal never matched.
- **1DS `userConsentDetails` now reports non-essential = denied until WCP resolves**, so no analytics cookie (`MSFPC`) is written before consent; 1DS still initializes unconditionally so **Required telemetry is always collected**.
- **On Analytics deny**, best-effort remove the non-essential dual-purpose `MSFPC` cookie while keeping the essential `MicrosoftApplicationsTelemetry*` telemetry cookies.

Consistent with Microsoft's Clarity cookie docs, which classify Clarity's cookies as **non-essential**: https://learn.microsoft.com/en-us/clarity/setup-and-installation/clarity-cookies

## Testing

- `npm test` → **373/373 pass**, including `test/consent-banner.test.ts`.
- `npm run build` → success.
- Playwright runtime check (served build, mocked WCP consent):
  - **No WCP / consent not given** → Required telemetry sent, essential telemetry cookie only; **no `MSFPC`, no Clarity/Bing cookies**.
  - **Analytics denied** → Required telemetry continues, essential telemetry cookie persists; **no `MSFPC`, no Clarity/Bing cookies**.
  - **Analytics granted** → Clarity/Bing cookies appear only then.

## Note

1DS / JSLL 4.2.3 telemetry (e.g. `MicrosoftApplicationsTelemetryDeviceId`) is treated as **essential / Required** and may be collected before consent — these cookies were not in the compliance scan's flagged list. This classification is worth a quick confirm with the privacy team, since the pre-consent behavior depends on it.
