### PR TITLE
Fix e2e gallery layout test broken by retired templates

### DIFF
--- a/website/e2e/extensions-layout.spec.ts
+++ b/website/e2e/extensions-layout.spec.ts
@@ -1,8 +1,48 @@
 import { test, expect } from "@playwright/test";
+import extensions from "../static/extensions.json";
+import templates from "../static/templates.json";
+
+const SPARSE_TAG = "swa";
+
+// Derived from the gallery data so retiring a template doesn't break this test.
+function sparseTemplateQuery() {
+  const match = (templates as any[]).find((template) =>
+    [
+      ...(template.tags ?? []),
+      ...(template.languages ?? []),
+      ...(template.frameworks ?? []),
+      ...(template.azureServices ?? []),
+      ...(template.IaC ?? []),
+    ].includes(SPARSE_TAG),
+  );
+
+  if (!match) {
+    throw new Error(`No template in templates.json is tagged "${SPARSE_TAG}"`);
+  }
+
+  const params = new URLSearchParams({ tags: SPARSE_TAG, name: match.title });
+  return `templates?${params.toString()}`;
+}
+
+function sparseExtensionQuery() {
+  const displayNames = (extensions as any[]).map((extension) => extension.displayName);
+  const unique = displayNames.find(
+    (displayName) =>
+      displayNames.filter((other) => other.toLowerCase().includes(displayName.toLowerCase()))
+        .length === 1,
+  );
+
+  if (!unique) {
+    throw new Error("No extension in extensions.json has a uniquely matching display name");
+  }
+
+  const params = new URLSearchParams({ name: unique });
+  return `extensions?${params.toString()}`;
+}
 
 test.describe("Gallery card layout", () => {
   test("sparse gallery results stay left aligned", async ({ page }) => {
-    await page.goto("templates?tags=swa&name=Static+React+Web+App");
+    await page.goto(sparseTemplateQuery());
     await page.waitForSelector('[data-testid="showcase-list"] .fui-Card');
 
     async function expectLeftAlignedGrid() {
@@ -19,7 +59,7 @@ test.describe("Gallery card layout", () => {
 
     await expectLeftAlignedGrid();
 
-    await page.goto("extensions?name=Concurx");
+    await page.goto(sparseExtensionQuery());
     await page.waitForSelector('[data-testid="showcase-list"] .fui-Card');
     await expect(page.locator('[data-testid="showcase-list"] .fui-Card')).toHaveCount(1);
     await expectLeftAlignedGrid();


### PR DESCRIPTION
## Problem

The [Release Awesome Azd run](https://github.com/Azure/awesome-azd/actions/runs/32230117394/job/96003289767) is failing on the `Gallery card layout › sparse gallery results stay left aligned` Playwright test:

```
Error: page.waitForSelector: Test timeout of 30000ms exceeded.
  - waiting for locator('[data-testid="showcase-list"] .fui-Card') to be visible
> 6 |     await page.waitForSelector('[data-testid="showcase-list"] .fui-Card');
```

## Root cause

`website/e2e/extensions-layout.spec.ts` hardcodes a gallery query:

```ts
await page.goto("templates?tags=swa&name=Static+React+Web+App");
```

#960 ("Retire unhealthy templates and add repository health monitoring") removed the `Static React Web App + ...` templates from `templates.json`. That query now matches **0** templates, so no card ever renders and the test times out.

To confirm, filtering the current `templates.json` the same way the gallery does:

```
swa tagged: 12   name hits: 0
```

## Fix

Derive the template and extension queries from `templates.json` / `extensions.json` at test time instead of hardcoding names, so retiring gallery data can't break the layout assertions again. The test still asserts the same thing: a sparse result set stays left-aligned and columns don't stretch past 350px.

## Validation

Reproduced the CI failure locally against a fresh production build, then verified the fix:

| | before | after |
| --- | --- | --- |
| `extensions-layout.spec.ts` | 1 failed, 1 passed | 2 passed |

- Full Playwright suite: **29 passed**
- `npm test` (Jest): **398 passed**

> Note: a stale `docusaurus start` server from another worktree on port 3000 initially masked the failure by serving pre-#960 data. Validation above was run against a fresh `npm run build` + `npm run serve` on an isolated port.