### PR TITLE
Update Playwright and add release test bypass

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,11 @@ name: Release Awesome Azd
 # This pipeline is manually started only as part of releasing Awesome AZD
 on:
   workflow_dispatch:
+    inputs:
+      skip_website_testing:
+        description: Skip website testing before deployment
+        type: boolean
+        default: false
 
 permissions:
   id-token: write
@@ -30,13 +35,20 @@ jobs:
   test-website:
     name: Website Testing
     needs: guard
+    if: ${{ !inputs.skip_website_testing }}
     uses: ./.github/workflows/website-test.yml
     permissions:
       contents: read
 
   deploy:
     name: Deploy Site To GitHub Pages
-    needs: test-website
+    needs:
+      - guard
+      - test-website
+    if: >-
+      always() &&
+      needs.guard.result == 'success' &&
+      (inputs.skip_website_testing || needs.test-website.result == 'success')
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -23,7 +23,7 @@
         "@fluentui/react": "^8.125.6",
         "@fluentui/react-components": "^9.73.8",
         "@mdx-js/react": "^3.0.0",
-        "@playwright/test": "^1.60.0",
+        "@playwright/test": "^1.62.1",
         "@types/react-dom": "^19.2.3",
         "babel-jest": "^30.4.1",
         "clsx": "^2.0.0",
@@ -10456,19 +10456,19 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
-      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.60.0"
+        "playwright": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -22042,35 +22042,35 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
-      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.60.0"
+        "playwright-core": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
-      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/playwright/node_modules/fsevents": {

--- a/website/package.json
+++ b/website/package.json
@@ -26,7 +26,7 @@
     "@fluentui/react": "^8.125.6",
     "@fluentui/react-components": "^9.73.8",
     "@mdx-js/react": "^3.0.0",
-    "@playwright/test": "^1.60.0",
+    "@playwright/test": "^1.62.1",
     "@types/react-dom": "^19.2.3",
     "babel-jest": "^30.4.1",
     "clsx": "^2.0.0",


### PR DESCRIPTION
## Summary
- update Playwright from 1.60.0 to 1.62.1
- add a release dispatch checkbox to skip website testing
- allow deployment after the guard succeeds when testing is explicitly skipped

## Validation
- npm test
- npm run build
- npx playwright test (29 passed)
- release workflow YAML lint