### PR TITLE
Configure delayed GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary

- configure Dependabot to monitor GitHub Actions dependencies daily
- delay newly released action versions for seven days before Dependabot proposes updates

All external action references on `main` are already pinned to immutable commit SHAs.

Fix https://github.com/Azure/ai-app-templates/issues/823