### PR TITLE
ci: add 7-day cooldown for website npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,9 @@ updates:
       interval: "daily"
     cooldown:
       default-days: 7
+  - package-ecosystem: "npm"
+    directory: "/website"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary

- Add a 7-day Dependabot cooldown for npm updates in `/website`.
- Prevent newly published npm versions from being proposed until they have aged for seven days.

## Context

PR #987 was opened for a newly released `fast-uri` version before the repository had an npm cooldown. This replacement separates the Dependabot policy change from that dependency update and leaves the current npm dependencies unchanged.