### PR TITLE
ci: group monthly npm dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,13 @@ updates:
   - package-ecosystem: "npm"
     directory: "/website"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     cooldown:
       default-days: 7
+    groups:
+      website-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

- Change website npm Dependabot checks from daily to monthly.
- Group minor and patch updates into a single pull request.
- Retain the existing seven-day package cooldown.

## Context

Follow-up to #988. The cooldown prevents newly published versions from being proposed immediately, while the monthly schedule and grouping reduce routine dependency-update PR noise. Major updates remain separate, and security updates remain immediate.